### PR TITLE
repayment model attributes default state is now 0

### DIFF
--- a/app/models/mortgage_calculator/repayment.rb
+++ b/app/models/mortgage_calculator/repayment.rb
@@ -9,14 +9,14 @@ module MortgageCalculator
 
     currency_inputs :debt
 
-    validates :term_years, presence: true
+    validates :term_years, presence: true, numericality: {greater_than: 0}
     validates :debt, presence: true
-    validates :interest_rate, presence: true
+    validates :interest_rate, presence: true, numericality: {greater_than: 0}
 
     def initialize(options = {})
-      self.debt = options.fetch(:debt){ nil }
-      self.term_years = options.fetch(:term_years){ nil }
-      self.interest_rate = options.fetch(:interest_rate){ nil }
+      self.debt = options.fetch(:debt){ 0 }
+      self.term_years = options.fetch(:term_years){ 0 }
+      self.interest_rate = options.fetch(:interest_rate){ 0 }
     end
 
     def term_years=(value)

--- a/spec/models/repayment_spec.rb
+++ b/spec/models/repayment_spec.rb
@@ -11,6 +11,14 @@ describe MortgageCalculator::Repayment do
     its(:interest_rate){ should == 7.5 }
   end
 
+  describe 'defaults' do
+    subject{ described_class.new }
+
+    its(:debt){ should be_zero }
+    its(:term_years){ should be_zero }
+    its(:interest_rate){ should be_zero }
+  end
+
   describe 'validations' do
     context 'when debt is blank' do
       subject{ described_class.new debt: "", term_years: "25", interest_rate: "7.5" }
@@ -34,6 +42,20 @@ describe MortgageCalculator::Repayment do
       it 'is not valid' do
         subject.should_not be_valid
       end
+    end
+
+    it 'interest rate must be greater than zero' do
+      subject = described_class.new debt: "100000", term_years: "25", interest_rate: "0"
+      subject.should_not be_valid
+      subject = described_class.new debt: "100000", term_years: "25", interest_rate: "0.01"
+      subject.should be_valid
+    end
+
+    it 'term years must be greater than zero' do
+      subject = described_class.new debt: "100000", term_years: "0", interest_rate: "1"
+      subject.should_not be_valid
+      subject = described_class.new debt: "100000", term_years: "25", interest_rate: "1"
+      subject.should be_valid
     end
   end
 


### PR DESCRIPTION
this is so the when user loads the form they see 0 in the form fields
