### PR TITLE
Adding hide classes to initial page load to avoid FOUC

### DIFF
--- a/app/views/mortgage_calculator/repayments/show.html.erb
+++ b/app/views/mortgage_calculator/repayments/show.html.erb
@@ -7,18 +7,18 @@
 
   <div wizard on-finish="finishedWizard()" hide-indicators='true'>
 
-    <div wz-step >
+    <div wz-step class="ng-hide">
       <%= render 'form_step1' %>
     </div>
 
-    <div wz-step >
+    <div wz-step class="ng-hide">
       <div class="rendered-from-js">
         <%= render 'calc_left_panel' %>
         <%= render 'calc_right_panel' %>
       </div>
     </div>
 
-    <div wz-step >
+    <div wz-step class="ng-hide">
       <div class="rendered-from-js">
         <%= render 'next_steps_content' %>
       </div>

--- a/app/views/mortgage_calculator/stamp_duties/show.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/show.html.erb
@@ -6,11 +6,11 @@
   <% end %>
 
   <div wizard on-finish="finishedWizard()" hide-indicators='true'>
-    <div wz-step >
+    <div wz-step class="ng-hide">
       <%= render 'form_step1' %>
     </div>
 
-    <div wz-step >
+    <div wz-step class="ng-hide">
       <div class="rendered-from-js">
         <%= render 'calc_left_panel' if @stamp_duty.valid? %>
         <%= render 'calc_right_panel' %>
@@ -21,7 +21,7 @@
       </div>
     </div>
 
-    <div wz-step >
+    <div wz-step class="ng-hide">
       <div class="rendered-from-js">
         <%= render 'next_steps_content' %>
       </div>


### PR DESCRIPTION
Fixes #55 

Still get a slight jump and you can't see the calculator until loading has finished, but at least the user doesn't see the unstyled templates (which aren't functional anyway).
