### PR TITLE
Raise exceptions in dev/test if incorrect or missing translation keys are encountered

### DIFF
--- a/spec/dummy/config/initializers/i18n.rb
+++ b/spec/dummy/config/initializers/i18n.rb
@@ -1,1 +1,10 @@
 I18n.enforce_available_locales = true
+
+# raise exceptions when there is an incorrect or missing i18n key
+# in development and test
+module I18n
+  def self.just_raise_that_exception(*args)
+    raise "i18n #{args.first}"
+  end
+end
+I18n.exception_handler = :just_raise_that_exception


### PR DESCRIPTION
This proved very useful in the payday loans tool and the budget planner. Shall we include it on mortgage calculator?
