### PR TITLE
Change radio buttons to checkbox and use form__item to position elements

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/base/_forms.scss
+++ b/app/assets/stylesheets/mortgage_calculator/base/_forms.scss
@@ -1,10 +1,13 @@
+.form__item {
+  margin: $baseline-unit*3 0 0;
+}
+
 label {
   display: block;
-  position: relative;
   font-weight: 500;
   font-size:18px;
-  margin: 18px 0 6px;
   color: $color-grey-primary;
+  margin-bottom: $baseline-unit;
 }
 
 .field_with_errors {

--- a/app/views/mortgage_calculator/affordabilities/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step1.html.erb
@@ -76,7 +76,7 @@
       <% person.object_name = "affordability[people_attributes][#{count}]" %>
 
       <% if count == 0 %>
-        <div class="form_item">
+        <div class="form__item">
           <%= f.errors_for person.object, :monthly_net_income %>
           <%= person.label :monthly_net_income, I18n.t("affordability.activemodel.attributes.mortgage_calculator/person.monthly_net_income_0") %>
           <%= person.text_field :monthly_net_income,
@@ -89,7 +89,7 @@
                                 "value" => person.object.monthly_net_income_formatted %>
         </div>
       <% else %>
-        <div class="form_item">
+        <div class="form__item">
           <%= f.errors_for person.object, :monthly_net_income %>
           <%= person.label :monthly_net_income, I18n.t("affordability.activemodel.attributes.mortgage_calculator/person.monthly_net_income_1") %>
           <%= person.text_field :monthly_net_income,
@@ -108,7 +108,10 @@
 
   </div>
   <div class="mortgagecalc__panel mortgagecalc__panel--full">
-    <%= f.submit I18n.t("affordability.input_page.submit"),
+
+    <div class="form__item">
+      <%= f.submit I18n.t("affordability.input_page.submit"),
              class: "button button--primary mortgagecalc__submit" %>
+   </div>
   </div>
 <% end %>

--- a/app/views/mortgage_calculator/affordabilities/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step2.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <div class="mortgagecalc__panel">
-    <div class="form_field">
+    <div class="form__item">
       <%= outgoings.errors_for outgoings.object, :credit_repayments %>
       <%= outgoings.label :credit_repayments %>
       <%= outgoings.text_field :credit_repayments,
@@ -34,7 +34,7 @@
                             "data-m-dec" =>"0",
                             "value" => outgoings.object.credit_repayments_formatted %>
     </div>
-    <div class="form_field">
+    <div class="form__item">
       <%= outgoings.errors_for outgoings.object, :child_maintenance %>
       <%= outgoings.label :child_maintenance %>
       <%= outgoings.text_field :child_maintenance,
@@ -53,7 +53,7 @@
   </div>
 
   <div class="mortgagecalc__panel">
-    <div class="form_field">
+    <div class="form__item">
       <%= outgoings.errors_for outgoings.object, :childcare %>
       <%= outgoings.label :childcare %>
       <%= outgoings.text_field :childcare,
@@ -76,7 +76,7 @@
                             "data-m-dec" =>"0",
                             "value" => outgoings.object.travel_formatted %>
     </div>
-    <div class="form_field">
+    <div class="form__item">
       <%= outgoings.errors_for outgoings.object, :utilities %>
       <%= outgoings.label :utilities %>
       <%= outgoings.text_field :utilities,
@@ -107,7 +107,7 @@
     </div>
 
     <div class="mortgagecalc__panel">
-      <div class="form_field">
+      <div class="form__item">
         <%= outgoings.errors_for outgoings.object, :entertainment %>
         <%= outgoings.label :entertainment %>
         <%= outgoings.text_field :entertainment,
@@ -130,7 +130,7 @@
                               "data-m-dec" =>"0",
                               "value" => outgoings.object.holidays_formatted %>
       </div>
-      <div class="form_field">
+      <div class="form__item">
         <%= outgoings.errors_for outgoings.object, :food %>
         <%= outgoings.label :food %>
         <%= outgoings.text_field :food,
@@ -146,7 +146,9 @@
   <% end %>
 
   <div class="mortgagecalc__panel mortgagecalc__panel--full">
-    <%= f.submit I18n.t("affordability.input_page.submit"),
+    <div class="form__item form__item--spaced">
+      <%= f.submit I18n.t("affordability.input_page.submit"),
              class: "button button--primary mortgagecalc__submit" %>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
Follows more `dough` styling by removing more of ours and uses checkbox instead of radio button on first page.
