### PR TITLE
Setting no-store cache header to retain value with browser back button

### DIFF
--- a/app/controllers/mortgage_calculator/affordabilities_controller.rb
+++ b/app/controllers/mortgage_calculator/affordabilities_controller.rb
@@ -2,11 +2,13 @@ module MortgageCalculator
   # Load order issue - subclass a class explicitly
   class AffordabilitiesController < ::MortgageCalculator::ApplicationController
     def step_1
+      response.headers["Cache-Control"] = "no-store"
       @affordability = AffordabilityPresenter.new(affordability_model)
       @affordability.valid? unless @affordability.empty?
     end
 
     def step_2
+      response.headers["Cache-Control"] = "no-store"
       persist_affordability_params_to_session
 
       @affordability = AffordabilityPresenter.new(affordability_model)


### PR DESCRIPTION
For discussion - this makes for more expected behaviour.

Use Chrome, with Javascript enabled, with a fresh session:
- Enter £50,000 into annual income
- Enter £500 into monthly take home
- Hit next
- Hit Browser back button
- See values you'd inputted

Try the same steps on master branch, and you see empty values until you refresh the page.
