### PR TITLE
Re-enable featured-list styling.

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_featured-list.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_featured-list.scss
@@ -12,41 +12,40 @@
     font-size: $font-large;
     font-weight: 500;
   }
-}
 
-.gt-ie8 {
-  .featured-list {
+  @if $responsive == true {
+
     > li {
-        position:relative;
-        margin:0 0 30px 2.3em;
-        padding:4px 8px;
-        list-style:none;
+        position: relative;
+        margin: 0 0 30px 2.3em;
+        padding: 4px 8px;
+        list-style: none;
         min-height: 60px;
     }
 
     > li:before {
-        content:counter(li);
-        counter-increment:li;
+        content: counter(li);
+        counter-increment: li;
 
-        position:absolute;
-        top:-2px;
-        margin-left:-75px;
-        box-sizing:border-box;
-        width:1.8em;
-        height:1.8em;
+        position: absolute;
+        top: -2px;
+        margin-left: -75px;
+        box-sizing: border-box;
+        width: 1.8em;
+        height: 1.8em;
         border-radius: 1.8em;
-        padding:4px;
-        color:#333;
-        background:#ecd600;
-        font-weight:500;
+        padding: 4px;
+        color: #333;
+        background: #ecd600;
+        font-weight: 500;
         font-family: 'museo_sans';
-        font-size:$font-xlarge;
-        text-align:center;
+        font-size: $font-xlarge;
+        text-align: center;
         line-height: 1.65em;
     }
+
   }
 }
-
 
 .featured-list--left {
   float: left;


### PR DESCRIPTION
When embedded in old site, the calculator used the convenience class `gte-ie8` to conditionally serve a fancy featured-list style, using `counter` and `counter-increment`.

Since this class doesn't exist in frontend, we stop relying on this class, and instead use `$responsive` to conditionally serve the fancy style. Can anyone think of a more 'semantically correct' way of doing this within Dough? There doesn't seem to be a Modernizr test for the `counter` properties it relies on.

In case you were wondering, this is what it looks like in IE8 if the fancy style is served anyway:

![screenshot 2014-10-21 14 51 47](https://cloud.githubusercontent.com/assets/1007202/4719406/70022d48-5929-11e4-9911-33f37be2e01c.png)
