### PR TITLE
Remove mas-development_dependencies and replace with equivalent code.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,9 @@ group :test do
   gem 'shoulda-matchers', "2.7.0"
   gem 'simplecov', :require => false
   gem 'sqlite3'
+  gem 'timecop'
+  gem 'cucumber-rails', :require => false
+  gem 'capybara-screenshot'
+  gem 'poltergeist'
+  gem 'site_prism'
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,9 +1,36 @@
-
 ENV["RAILS_ROOT"] ||= File.dirname(__FILE__) + "../../../spec/dummy"
 
-require 'mas/development_dependencies/cucumber/env'
+require 'cucumber/rails'
+
+require 'capybara'
+require 'capybara-screenshot'
+require 'capybara-screenshot/cucumber'
+require 'capybara/poltergeist'
+require 'site_prism'
+require 'timecop'
+
+Time.zone = 'London'
+
+ActionController::Base.allow_rescue = false
+
+if defined?(ActiveRecord)
+  DatabaseCleaner.strategy                      = :transaction
+  Cucumber::Rails::Database.javascript_strategy = :truncation
+else
+  Cucumber::Rails::Database.autorun_database_cleaner = false
+end
+
+if defined?(FactoryGirl)
+  Dir[Rails.root.join('./../factories/**/*.rb')].each { |f| require f }
+  World(FactoryGirl::Syntax::Methods)
+end
+
+Capybara.javascript_driver = :poltergeist
+
+After do
+  Timecop.return
+end
 
 SitePrism.configure do |config|
   config.use_implicit_waits = true
 end
-

--- a/lib/tasks/karma.rake
+++ b/lib/tasks/karma.rake
@@ -1,0 +1,49 @@
+namespace :karma  do
+
+  desc 'Install NPM modules'
+  task :install => :environment do
+    install_modules
+  end
+
+  desc 'Run the karma tests continuously'
+  task :run => :environment do
+    with_tmp_config :start
+  end
+
+  desc 'Run the karma tests once'
+  task :run_once => :environment do
+    with_tmp_config :start, "--single-run"
+  end
+
+
+  def with_tmp_config(command, args = nil)
+    $stderr.puts "--------------------------------------------------------------------------------------------"
+    $stderr.puts "CAUTION: this rake task only works when run from the immediate parent of your spec directory"
+    $stderr.puts "--------------------------------------------------------------------------------------------"
+    $stderr.puts
+
+    FileUtils.mkdir('tmp') unless Dir.exists?('tmp')
+    Tempfile.open('karma_unit.js', File.expand_path('tmp')) do |f|
+      f.write unit_js(application_spec_files)
+      f.flush
+      sh "./node_modules/karma/bin/karma #{command} #{f.path} #{args}"
+    end
+  end
+
+  def application_spec_files
+    sprockets = Rails.application.assets
+    sprockets.append_path File.expand_path("spec/javascripts")
+    sprockets.find_asset("application_spec.js").to_a.map {|e| e.pathname.to_s }
+  end
+
+  def unit_js(files)
+    unit_js = File.open('spec/javascripts/karma.conf.js', 'r').read
+
+    unit_js.gsub "APPLICATION_SPEC", "\"#{files.join("\",\n\"")}\""
+  end
+
+  def install_modules
+    sh "npm install"
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,32 @@ SimpleCov.start 'rails'
 
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../dummy/config/environment.rb", __FILE__)
-require 'mas/development_dependencies/rspec/spec_helper'
+require 'rspec/rails'
+require 'timecop'
+
+Time.zone = 'London'
+
+Dir[Rails.root.join('./../support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('./../factories/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods if defined?(FactoryGirl)
+  config.include Devise::TestHelpers, :type => :controller if defined?(Devise)
+  config.include Rails.application.routes.url_helpers
+
+  config.infer_base_class_for_anonymous_controllers = false
+
+  config.use_transactional_fixtures = true if defined?(ActiveRecord)
+  config.order = 'random'
+  config.run_all_when_everything_filtered = true
+
   config.infer_spec_type_from_file_location!
+
+  config.before(:each) do
+    I18n.locale = :en if defined?(I18n)
+  end
+
+  config.after(:each) do
+    Timecop.return
+  end
 end


### PR DESCRIPTION
Today I decided to test out what `mas-development_dependencies` what actually doing by removing it and then adding stuff back in until the tests passed. This is what I came up with. Here's a brief summary:
- Requires a bunch of test gems.
- Sets up a base configuration for RSpec and Cucumber.
- Sets up rake tasks to run Karma.

The commit here is mostly copy-and-paste to add the above back in. Taking this approach generally would involve copy-pasting these files around and we all know how that ends up — very slightly differing versions of the same files across several different projects, and a corresponding itch to DRY up the lot.

Moreover, centralising agreed test config and non-trivial tasks like setting up Karma within a Rails env decreases the barrier-to-entry for testing, and that's always a good thing. It also standardises the test environment, which makes code reuse across projects easier.

There would seem to be an argument for adding some of this back into mas-devdep. It'd be great to hear your perspective on this, so we can all be on the same page when it comes to things like this in future, and decrease the likelihood of unexpected breaking changes.

CC @stevenwilkin @benlovell @baphled 
