### PR TITLE
Revert "Use h1 for mortgage calcs"

### DIFF
--- a/app/views/mortgage_calculator/affordabilities/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step1.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <div class="affcalc__col">
-    <h2><%= I18n.t("affordability.titles.annual_income") %></h2>
+    <h3><%= I18n.t("affordability.titles.annual_income") %></h3>
   </div>
 
   <%= f.fields_for :people do |person| %>
@@ -192,7 +192,7 @@
   <% end %>
 
   <div class="affcalc__col">
-    <h2><%= I18n.t("affordability.titles.take_home") %></h2>
+    <h3><%= I18n.t("affordability.titles.take_home") %></h3>
   </div>
 
   <%= f.fields_for :people do |person| %>

--- a/app/views/mortgage_calculator/affordabilities/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step2.html.erb
@@ -8,11 +8,11 @@
   <% f.validates @affordability, @affordability.outgoings %>
 
   <div class="affcalc__col--clip">
-    <h1><%= t("affordability.title") %></h1>
+    <h2><%= t("affordability.title") %></h2>
 
     <%= f.validation_summary %>
 
-    <h2><%= t("affordability.titles.monthly_outgoings") %></h2>
+    <h3><%= t("affordability.titles.monthly_outgoings") %></h3>
 
     <p><%= t("affordability.input_page.monthly_outgoings_descriptions_html") %></p>
     <p><strong><%= t("affordability.input_page.monthly_outgoings_descriptions_2_html") %></strong></p>
@@ -21,7 +21,7 @@
   </div>
 
   <div class="affcalc__col">
-    <h3><%= I18n.t("affordability.titles.estimated_committed") %></h3>
+    <h4><%= I18n.t("affordability.titles.estimated_committed") %></h4>
   </div>
 
   <%= f.fields_for :outgoings, @affordability.outgoings do |outgoings| %>
@@ -99,7 +99,7 @@
     </div>
 
 <div class="affcalc__col">
-  <h3><%= I18n.t("affordability.titles.estimated_fixed") %></h3>
+  <h4><%= I18n.t("affordability.titles.estimated_fixed") %></h4>
 </div>
 
 <div class="affcalc__row">
@@ -244,7 +244,7 @@
       <% end %>
 
   <div class="affcalc__col">
-    <h2><%= I18n.t("affordability.titles.estimated_lifestyle") %></h2>
+    <h3><%= I18n.t("affordability.titles.estimated_lifestyle") %></h3>
     <p><%= t "affordability.input_page.living_costs_description" %></p>
   </div>
 

--- a/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
@@ -1,5 +1,5 @@
 <div class="affcalc__col">
-  <h1><%= I18n.t("affordability.title") %></h1>
+  <h2><%= I18n.t("affordability.title") %></h2>
 </div>
 
 <%= form_for @affordability, builder: Dough::Forms::Builders::Validation, url: localize_route("step_3_affordability_path"), html: { name: 'affordability_form', role: 'form', class: 'step_two', novalidate: '', "ng-no-submit" => "" } do |f| %>
@@ -41,7 +41,7 @@
 
   <div class="affcalc__row">
     <div class="affcalc__col--clip" ng-cloak>
-      <h2><%= t "affordability.titles.how_affect_budget" %></h2>
+      <h3><%= t "affordability.titles.how_affect_budget" %></h3>
 
       <% if @affordability.only_rent_and_mortgage_warning? %>
         <%= inset_block(t("affordability.warnings.only_rent_and_mortgage_html",
@@ -71,7 +71,7 @@
 
   <div class="affcalc__row">
     <div class="affcalc__col--clip" ng-cloak>
-      <h2><%= t "affordability.titles.can_afford" %></h2>
+      <h3><%= t "affordability.titles.can_afford" %></h3>
 
       <% if @affordability.missing_lifestyle_costs_warning? %>
         <%= inset_block(t("affordability.warnings.missing_lifestyle_costs_html",
@@ -136,7 +136,7 @@
 
       <%= render "mortgage_calculator/affordabilities/form/remaining_vector" %>
 
-      <h2><%= t "affordability.interest_changer.title" %></h2>
+      <h3><%= t "affordability.interest_changer.title" %></h3>
       <%= render 'mortgage_calculator/affordabilities/form/interest_changes' %>
     </div>
   </div>

--- a/app/views/mortgage_calculator/affordabilities/_header.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_header.html.erb
@@ -1,5 +1,5 @@
 <div class="affcalc__col--clip">
-  <h1><%= I18n.t("affordability.title") %></h1>
+  <h2><%= I18n.t("affordability.title") %></h2>
 
   <p><%= I18n.t("affordability.preamble") %></p>
   <p><%= I18n.t("affordability.description") %></p>

--- a/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
@@ -1,5 +1,5 @@
 <div class="affcalc__col--clip">
-  <h2 class="mortgagecalc__heading"><%= t("affordability.next_steps.title") %></h2>
+  <h4 class="mortgagecalc__heading"><%= t("affordability.next_steps.title") %></h4>
 
   <ol class="featured-list">
     <li><strong><%= t("affordability.next_steps.tip_1.heading") %></strong> <%= link_to t("affordability.next_steps.tip_1.info_html"), t("affordability.next_steps.tip_1.url"), target: "_blank", rel: no_follow? %></li>
@@ -11,7 +11,7 @@
 <div class="affcalc__row">
   <div class="affcalc__col--33">
     <div class="callout">
-      <h3 class="mortgagecalc__subheading"><%= t("affordability.next_steps.learn_more.title") %>:</h3>
+      <h5 class="mortgagecalc__subheading"><%= t("affordability.next_steps.learn_more.title") %>:</h5>
 
       <% (1..2).each do |i| %>
         <p><%= t("affordability.next_steps.learn_more.tip_#{i}") %></p>
@@ -22,7 +22,7 @@
   </div>
 
   <div class="affcalc__col--33 mortgagecalc__panel mortgagecalc__panel--nudge">
-    <h3 class="mortgagecalc__subheading"><%= t("affordability.next_steps.find_out_more.title") %>:</h3>
+    <h5 class="mortgagecalc__subheading"><%= t("affordability.next_steps.find_out_more.title") %>:</h5>
     <ul>
       <% (1..7).each do |n| %>
         <li><%= link_to t("affordability.next_steps.find_out_more.tip_#{n}.copy_html"), t("affordability.next_steps.find_out_more.tip_#{n}.url"), target: "_blank", rel: no_follow? %></li>

--- a/app/views/mortgage_calculator/affordabilities/next_steps.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/next_steps.html.erb
@@ -1,6 +1,6 @@
 <div class="affcalc">
   <div class="affcalc__col">
-    <h1><%= I18n.t("affordability.title") %></h1>
+    <h2><%= I18n.t("affordability.title") %></h2>
   </div>
 
   <%= render 'next_steps_content'  %>

--- a/app/views/mortgage_calculator/repayments/_calc_left_panel.html.erb
+++ b/app/views/mortgage_calculator/repayments/_calc_left_panel.html.erb
@@ -28,7 +28,7 @@
 </div>
 
   <div class="callout">
-    <h4 class="callout__heading"><%= I18n.t("mortgage_calculator.repayment.interest_changer.title") %></h4>
+    <h5 class="callout__heading"><%= I18n.t("mortgage_calculator.repayment.interest_changer.title") %></h5>
     <p><%= raw I18n.t("mortgage_calculator.repayment.interest_changer.intro", change: 3) %></p>
 
      <div ng-show="viewMonthlyRepayments"><%= render 'monthly_increment' %></div>

--- a/app/views/mortgage_calculator/repayments/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/repayments/_form_step1.html.erb
@@ -1,6 +1,6 @@
 <div class="mortgagecalc__panel mortgagecalc__panel--full">
   <%= t("mortgage_calculator.repayment.step_1.intro_html") %>
-  <h2><%= t("mortgage_calculator.repayment.step_1.title") %></h2>
+  <h3><%= t("mortgage_calculator.repayment.step_1.title") %></h3>
 </div>
 
 <%= form_for @repayment, :html => {:class => "form step_one", novalidate: ''}, url: repayment_path do |f| %>

--- a/app/views/mortgage_calculator/repayments/_header.html.erb
+++ b/app/views/mortgage_calculator/repayments/_header.html.erb
@@ -1,3 +1,3 @@
 <div class="mortgagecalc__panel mortgagecalc__panel--full">
-  <h1><%= I18n.t("mortgage_calculator.repayment.title")%></h1>
+  <h2><%= I18n.t("mortgage_calculator.repayment.title")%></h2>
 </div>

--- a/app/views/mortgage_calculator/repayments/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/repayments/_next_steps_content.html.erb
@@ -1,5 +1,5 @@
 <div class="mortgagecalc__panel mortgagecalc__panel--full">
-  <h2 class="mortgagecalc__heading"><%= I18n.t("mortgage_calculator.repayment.next_steps.title") %></h2>
+  <h4 class="mortgagecalc__heading"><%= I18n.t("mortgage_calculator.repayment.next_steps.title") %></h4>
 
   <ol class="featured-list">
     <li><strong><%= I18n.t("mortgage_calculator.repayment.next_steps.tip_1.heading") %></strong> <%= link_to t("mortgage_calculator.repayment.next_steps.tip_1.info_html"), I18n.t("mortgage_calculator.repayment.next_steps.tip_1.url"), target: "_blank", rel: no_follow? %></li>
@@ -10,13 +10,13 @@
 
 <div class="mortgagecalc__panel">
   <div class="callout">
-    <h3 class="mortgagecalc__subheading"><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.title") %>:</h3>
+    <h5 class="mortgagecalc__subheading"><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.title") %>:</h5>
     <p><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.tip_1").html_safe %> <%= link_to t("mortgage_calculator.repayment.next_steps.learn_more.more.copy_html"), I18n.t("mortgage_calculator.repayment.next_steps.learn_more.more.url"), target: "_blank", rel: no_follow? %></p>
   </div>
 </div>
 
 <div class="mortgagecalc__panel mortgagecalc__panel--nudge">
-  <h3 class="mortgagecalc__subheading"><%= I18n.t("mortgage_calculator.repayment.next_steps.find_out_more.title") %>:</h3>
+  <h5 class="mortgagecalc__subheading"><%= I18n.t("mortgage_calculator.repayment.next_steps.find_out_more.title") %>:</h5>
   <ul>
   <% (1..6).each do |n| %>
     <li><%= link_to t("mortgage_calculator.repayment.next_steps.find_out_more.tip_#{n}.copy_html"), I18n.t("mortgage_calculator.repayment.next_steps.find_out_more.tip_#{n}.url"), target: "_blank", rel: no_follow? %></li>


### PR DESCRIPTION
Reverts moneyadviceservice/mortgage_calculator#224

Turns out the requirement was miscommunicated - we should be adding a new `h1` rather than changing the current h2.