### PR TITLE
fixing firefox issue 

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/directives/integer.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/directives/integer.js
@@ -2,7 +2,8 @@
 
 App.directive('integer', function () {
   var linker = function (scope, element, attrs, ctrl) {
-    element.on("keypress", function (event) {
+    // we were listening on keychange, however firefox doesn't allow you to edit the number in the textfield.
+    element.on("keyup", function (event) {
       // Keycodes for 0 to 9
       var permittedKeys = [48, 49, 50, 51, 52, 53, 54, 55, 56, 57];
 


### PR DESCRIPTION
fixing firefox issue where the mortgage_term field does not allow the user to change the value with the keyboard.