### PR TITLE
Mortgage affordability syndication

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
@@ -93,12 +93,11 @@
   font-size: px(40);
 }
 
-@media (max-width: 425px){
-  .mortgagecalc__submit{
+@media (max-width: $mq-s) {
+  .mortgagecalc__submit {
     max-width: 250px;
-    white-space: normal
+    white-space: normal;
   }
-
 }
 
 .mortgagecalc__submit {

--- a/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
@@ -93,6 +93,14 @@
   font-size: px(40);
 }
 
+@media (max-width: 425px){
+  .mortgagecalc__submit{
+    max-width: 250px;
+    white-space: normal
+  }
+
+}
+
 .mortgagecalc__submit {
   float:right;
   margin-bottom: 24px;

--- a/app/views/mortgage_calculator/affordabilities/form/_borrowing.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/form/_borrowing.html.erb
@@ -14,7 +14,7 @@
   "value" => @affordability.borrowing_formatted
 %>
 
-<div class="slider slider--with-follower-top slider--squeeze" ui-slider min="affordability.minimumBorrowing()" max="affordability.maximumBorrowing()" step="1000" ng-model="repayments.propertyPrice" label-follower="#borrowing-amount" aria-labelledby="borrowing-amount" analytics-category="Affordability Calculator" analytics-action="Refinement" analytics-label="Borrowing" id="slider-borrowing" ng-docked="docked"></div>
+<div class="slider slider--with-follower-top slider--squeeze" ui-slider min="affordability.minimumBorrowing()" max="affordability.maximumBorrowing()" step="10" ng-model="repayments.propertyPrice" label-follower="#borrowing-amount" aria-labelledby="borrowing-amount" analytics-category="Affordability Calculator" analytics-action="Refinement" analytics-label="Borrowing" id="slider-borrowing" ng-docked="docked"></div>
 
 <p class="rendered-from-js borrowing-range">
   <span class="borrowing-range__min">


### PR DESCRIPTION
Fixing 2 issues:
1: The second page of the affordability calc would not display correctly due to the width of the submit button text. The right hand side of the iframe ended up hidden.
2: The borrowing slider on the third page appeared to be inactive/disabled. We discovered that it was infact enabled, however the values of the slider were upset due to the input numbers not tying in exactly with the 'step' values. We reduced the step value.