### PR TITLE
Remove links to `news` articles, since they've been removed.

### DIFF
--- a/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
@@ -24,8 +24,8 @@
   <div class="affcalc__col--33 mortgagecalc__panel mortgagecalc__panel--nudge">
     <h5 class="mortgagecalc__subheading"><%= t("affordability.next_steps.find_out_more.title") %>:</h5>
     <ul>
-      <% (1..7).each do |n| %>
-        <li><%= link_to t("affordability.next_steps.find_out_more.tip_#{n}.copy_html"), t("affordability.next_steps.find_out_more.tip_#{n}.url"), target: "_blank", rel: no_follow? %></li>
+      <% I18n.t("affordability.next_steps.find_out_more.tips").each do |tip| %>
+        <li><%= link_to tip[:copy_html], tip[:url], target: "_blank", rel: no_follow? %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/mortgage_calculator/repayments/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/repayments/_next_steps_content.html.erb
@@ -18,8 +18,8 @@
 <div class="mortgagecalc__panel mortgagecalc__panel--nudge">
   <h5 class="mortgagecalc__subheading"><%= I18n.t("mortgage_calculator.repayment.next_steps.find_out_more.title") %>:</h5>
   <ul>
-  <% (1..6).each do |n| %>
-    <li><%= link_to t("mortgage_calculator.repayment.next_steps.find_out_more.tip_#{n}.copy_html"), I18n.t("mortgage_calculator.repayment.next_steps.find_out_more.tip_#{n}.url"), target: "_blank", rel: no_follow? %></li>
+  <% I18n.t("mortgage_calculator.repayment.next_steps.find_out_more.tips").each do |tip| %>
+    <li><%= link_to tip[:copy_html].html_safe, tip[:url], target: "_blank", rel: no_follow? %></li>
   <% end %>
   </ul>
 
@@ -42,4 +42,3 @@
 </div>
 
 <p><a href="#" class='button mortgagecalc__submit rendered-from-js' ng-click="navigateAndFocus($event, 'previous')"><%= I18n.t('mortgage_calculator.repayment.back') %></a></p>
-

--- a/config/locales/affordability.cy.yml
+++ b/config/locales/affordability.cy.yml
@@ -179,27 +179,19 @@ cy:
           url: "https://www.moneyadviceservice.org.uk/cy/articles/faint-allwch-chi-fforddio-ei-fenthyca"
       find_out_more:
         title: "Cewch fwy o wybodaeth yn"
-        tip_1:
-          copy_html: "Costau prynu"
-          url: "https://www.moneyadviceservice.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
-        tip_2:
-          copy_html: "Cynllunydd Cyllideb"
-          url: "https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb"
-        tip_3:
-          copy_html: "Mwy am gyfraddau llog"
-          url: "https://www.moneyadviceservice.org.uk/en/news/how-will-interest-rate-rises-affect-you"
-        tip_4:
-          copy_html: "Gwella eich statws credyd"
-          url: "https://www.moneyadviceservice.org.uk/cy/articles/sut-mae-gwella-eich-statws-credyd"
-        tip_5:
-          copy_html: "Cynlluniau tai fforddiadwy"
-          url: "https://www.moneyadviceservice.org.uk/cy/articles/homebuy-firstbuy-a-chynlluniau-tai-fforddiadwy-eraill"
-        tip_6:
-          copy_html: "Cynilo ar gyfer blaendal"
-          url: "https://www.moneyadviceservice.org.uk/cy/tools/cynilo-ar-gyfer-blaendal"
-        tip_7:
-          copy_html: "Tabl cymharu morgeisi"
-          url: "https://compare.moneyadviceservice.org.uk/mortgages/step1?language=cy"
+        tips:
+          - copy_html: "Costau prynu"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
+          - copy_html: "Cynllunydd Cyllideb"
+            url: "https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb"
+          - copy_html: "Gwella eich statws credyd"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/sut-mae-gwella-eich-statws-credyd"
+          - copy_html: "Cynlluniau tai fforddiadwy"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/homebuy-firstbuy-a-chynlluniau-tai-fforddiadwy-eraill"
+          - copy_html: "Cynilo ar gyfer blaendal"
+            url: "https://www.moneyadviceservice.org.uk/cy/tools/cynilo-ar-gyfer-blaendal"
+          - copy_html: "Tabl cymharu morgeisi"
+            url: "https://compare.moneyadviceservice.org.uk/mortgages/step1?language=cy"
       have_you_tried:
         title: "Rhowch gynnig ar"
         mortgage_calculator: "Cyfrifiannell Morgais"

--- a/config/locales/affordability.en.yml
+++ b/config/locales/affordability.en.yml
@@ -179,27 +179,19 @@ en:
           url: "https://www.moneyadviceservice.org.uk/en/articles/how-much-can-you-afford-to-borrow"
       find_out_more:
         title: "Find out more"
-        tip_1:
-          copy_html: "Costs of buying"
-          url: "https://www.moneyadviceservice.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
-        tip_2:
-          copy_html: "Budget Planner"
-          url: "https://www.moneyadviceservice.org.uk/en/tools/budget-planner"
-        tip_3:
-          copy_html: "More about interest rates"
-          url: "https://www.moneyadviceservice.org.uk/en/news/how-will-interest-rate-rises-affect-you"
-        tip_4:
-          copy_html: "Improve your credit rating"
-          url: "https://www.moneyadviceservice.org.uk/en/articles/how-to-improve-your-credit-rating"
-        tip_5:
-          copy_html: "Affordable housing schemes"
-          url: "https://www.moneyadviceservice.org.uk/en/categories/affordable-housing-schemes"
-        tip_6:
-          copy_html: "Saving for a deposit"
-          url: "https://www.moneyadviceservice.org.uk/en/tools/saving-for-a-deposit"
-        tip_7:
-          copy_html: "Mortgage comparison table"
-          url: "https://compare.moneyadviceservice.org.uk/mortgages/step1"
+        tips:
+          - copy_html: "Costs of buying"
+            url: "https://www.moneyadviceservice.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
+          - copy_html: "Budget Planner"
+            url: "https://www.moneyadviceservice.org.uk/en/tools/budget-planner"
+          - copy_html: "Improve your credit rating"
+            url: "https://www.moneyadviceservice.org.uk/en/articles/how-to-improve-your-credit-rating"
+          - copy_html: "Affordable housing schemes"
+            url: "https://www.moneyadviceservice.org.uk/en/categories/affordable-housing-schemes"
+          - copy_html: "Saving for a deposit"
+            url: "https://www.moneyadviceservice.org.uk/en/tools/saving-for-a-deposit"
+          - copy_html: "Mortgage comparison table"
+            url: "https://compare.moneyadviceservice.org.uk/mortgages/step1"
       have_you_tried:
         title: "Have you tried?"
         mortgage_calculator: "Mortgage Calculator"

--- a/config/locales/mortgage_calculator.cy.yml
+++ b/config/locales/mortgage_calculator.cy.yml
@@ -68,24 +68,17 @@ cy:
             url: "https://www.moneyadviceservice.org.uk/cy/articles/dewis-morgais-sut-mae-cael-y-cynnig-iawn"
         find_out_more:
           title: Dewch o hyd i ragor
-          tip_1:
-            copy_html: "Cymharu morgeisi <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
-            url: "https://compare.moneyadviceservice.org.uk/mortgages/step1?language=cy"
-          tip_2:
-            copy_html: "Dewis y morgais cywir <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
-            url: "https://www.moneyadviceservice.org.uk/cy/action_plans/sut-i-ddewis-y-morgais-cywir"
-          tip_3:
-            copy_html: "Cynlluniau tai fforddiadwy <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
-            url: "https://www.moneyadviceservice.org.uk/cy/articles/homebuy-firstbuy-a-chynlluniau-tai-fforddiadwy-eraill"
-          tip_4:
-            copy_html: "Cyfraddau llog <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
-            url: "https://www.moneyadviceservice.org.uk/cy/articles/cyfraddau-llogau-morgeisi-y-mathau-gwahanol"
-          tip_5:
-            copy_html: "Ystyriwch gostau erail <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
-            url: "https://www.moneyadviceservice.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
-          tip_6:
-            copy_html: "Codiadau mewn cyfraddau llog: Dyma beth allwch chi wneud nawr <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
-            url: "https://www.moneyadviceservice.org.uk/cy/news/cyfraddau-llog-beth-all-perchnogion-cartrefi-ei-wneud-nawr-i-drechuar-codiad"
+          tips:
+            - copy_html: "Cymharu morgeisi <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
+              url: "https://compare.moneyadviceservice.org.uk/mortgages/step1?language=cy"
+            - copy_html: "Dewis y morgais cywir <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
+              url: "https://www.moneyadviceservice.org.uk/cy/action_plans/sut-i-ddewis-y-morgais-cywir"
+            - copy_html: "Cynlluniau tai fforddiadwy <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
+              url: "https://www.moneyadviceservice.org.uk/cy/articles/homebuy-firstbuy-a-chynlluniau-tai-fforddiadwy-eraill"
+            - copy_html: "Cyfraddau llog <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
+              url: "https://www.moneyadviceservice.org.uk/cy/articles/cyfraddau-llogau-morgeisi-y-mathau-gwahanol"
+            - copy_html: "Ystyriwch gostau erail <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
+              url: "https://www.moneyadviceservice.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
         have_you_tried:
           title: 'Rhowch gynnig ar?'
           stamp_duty: "cyfrifiannell Treth Stamp"

--- a/config/locales/mortgage_calulator.en.yml
+++ b/config/locales/mortgage_calulator.en.yml
@@ -67,24 +67,17 @@ en:
             url: "https://www.moneyadviceservice.org.uk/en/articles/choosing-a-mortgage-shop-around-or-get-advice"
         find_out_more:
           title: Find out more
-          tip_1:
-            copy_html: "Mortgage comparison table <span class='visually-hidden'>(opens in a new window)</span>"
-            url: "https://compare.moneyadviceservice.org.uk/mortgages/step1"
-          tip_2:
-            copy_html: "Choose the right mortgage <span class='visually-hidden'>(opens in a new window)</span>"
-            url: "https://www.moneyadviceservice.org.uk/en/action_plans/how-to-choose-the-right-mortgage"
-          tip_3:
-            copy_html: "Affordable housing schemes <span class='visually-hidden'>(opens in a new window)</span>"
-            url: "https://www.moneyadviceservice.org.uk/en/articles/help-to-buy-homebuy-and-other-housing-schemes"
-          tip_4:
-            copy_html: "Interest rates explained <span class='visually-hidden'>(opens in a new window)</span>"
-            url: "https://www.moneyadviceservice.org.uk/en/articles/mortgage-interest-rate-options"
-          tip_5:
-            copy_html: "Think about other costs <span class='visually-hidden'>(opens in a new window)</span>"
-            url: "https://www.moneyadviceservice.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
-          tip_6:
-            copy_html: "Interest rate rises: What you can do now <span class='visually-hidden'>(opens in a new window)</span>"
-            url: "https://www.moneyadviceservice.org.uk/en/news/interest-rates-what-home-owners-can-do-now-to-beat-the-rise"
+          tips:
+            - copy_html: "Mortgage comparison table <span class='visually-hidden'>(opens in a new window)</span>"
+              url: "https://compare.moneyadviceservice.org.uk/mortgages/step1"
+            - copy_html: "Choose the right mortgage <span class='visually-hidden'>(opens in a new window)</span>"
+              url: "https://www.moneyadviceservice.org.uk/en/action_plans/how-to-choose-the-right-mortgage"
+            - copy_html: "Affordable housing schemes <span class='visually-hidden'>(opens in a new window)</span>"
+              url: "https://www.moneyadviceservice.org.uk/en/articles/help-to-buy-homebuy-and-other-housing-schemes"
+            - copy_html: "Interest rates explained <span class='visually-hidden'>(opens in a new window)</span>"
+              url: "https://www.moneyadviceservice.org.uk/en/articles/mortgage-interest-rate-options"
+            - copy_html: "Think about other costs <span class='visually-hidden'>(opens in a new window)</span>"
+              url: "https://www.moneyadviceservice.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
         have_you_tried:
           title: 'Have you tried?'
           stamp_duty: "Stamp Duty calculator"

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -56,8 +56,6 @@ cy:
             url: "https://www.moneyadviceservice.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
           - copy_html: "Ffioedd a chostau morgais"
             url: "https://www.moneyadviceservice.org.uk/cy/articles/cipolwg-ar-ffioedd-a-chostau-syn-gysylltiedig-a-morgeisi"
-          - copy_html: "Costau argyfwng"
-            url: "https://www.moneyadviceservice.org.uk/cy/news/prynwyr-tro-cyntaf-yn-amharod-am-gostau-argyfwng"
           - copy_html: "Costau diwrnod symud"
             url: "https://www.moneyadviceservice.org.uk/cy/articles/cynllunio-ar-gyfer-cost-diwrnod-symud"
       have_you_tried:

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -56,8 +56,6 @@ en:
             url: "https://www.moneyadviceservice.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
           - copy_html: Mortgage fees and costs
             url: "https://www.moneyadviceservice.org.uk/en/articles/mortgage-related-fees-and-costs-at-a-glance"
-          - copy_html: Emergency costs
-            url: "https://www.moneyadviceservice.org.uk/en/news/too-many-first-time-buyers-unprepared-for-emergency-costs-14022014"
           - copy_html: Costs of moving day
             url: "https://www.moneyadviceservice.org.uk/en/articles/planning-for-the-cost-of-moving-day"
       have_you_tried:


### PR DESCRIPTION
Welsh ones still work, but we'll remove them too for consistency.

We've also refactored the tips display in all three calculators to match the style used in the stamp duty calculator — iterating over a yaml array of tips rather than over a fixed number.