### PR TITLE
Replace old stamp duty results with new legislation

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
@@ -136,6 +136,23 @@
   margin-bottom: 78px;
 }
 
+.mortgagecalc__table__price {
+  width: 50%;
+
+  @include respond-to($mq-xs-max) {
+    width: 40%;
+  }
+}
+
+.mortgagecalc__table__rate,
+.mortgagecalc__table__extra {
+  width: 25%;
+
+  @include respond-to($mq-xs-max) {
+    width: 30%;
+  }
+}
+
 .js {
   .label-follower[type="text"] {
     @extend %font-heading-heavy;

--- a/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
@@ -4,41 +4,41 @@
   <table class="mortgagecalc__table">
     <thead>
       <tr>
-        <th><%= I18n.t("stamp_duty.table.property_price_header") %></th>
-        <th><%= I18n.t("stamp_duty.table.rate_header") %></th>
-        <th><%= I18n.t("stamp_duty.table.extra_rate_header") %></th>
+        <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
+        <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
+        <th class="mortgagecalc__table__extra"><%= I18n.t("stamp_duty.table.extra_rate_header") %></th>
       </tr>
     </thead>
 
     <tbody>
       <tr>
-        <td>&pound;0 - &pound;125,000</td>
-        <td>0%</td>
-        <td>3%</td>
+        <td class="mortgagecalc__table__price">&pound;0 - &pound;125,000</td>
+        <td class="mortgagecalc__table__rate">0%</td>
+        <td class="mortgagecalc__table__extra">3%</td>
       </tr>
 
       <tr>
-        <td>&pound;125,001 - &pound;250,000</td>
-        <td>2%</td>
-        <td>5%</td>
+        <td class="mortgagecalc__table__price">&pound;125,001 - &pound;250,000</td>
+        <td class="mortgagecalc__table__rate">2%</td>
+        <td class="mortgagecalc__table__extra">5%</td>
       </tr>
 
       <tr>
-        <td>&pound;250,001 - &pound;925,000</td>
-        <td>5%</td>
-        <td>8%</td>
+        <td class="mortgagecalc__table__price">&pound;250,001 - &pound;925,000</td>
+        <td class="mortgagecalc__table__rate">5%</td>
+        <td class="mortgagecalc__table__extra">8%</td>
       </tr>
 
       <tr>
-        <td>&pound;925,001 - &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
-        <td>10%</td>
-        <td>13%</td>
+        <td class="mortgagecalc__table__price">&pound;925,001 - &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
+        <td class="mortgagecalc__table__rate">10%</td>
+        <td class="mortgagecalc__table__extra">13%</td>
       </tr>
 
       <tr>
-        <td><%= I18n.t("stamp_duty.table.over") %> &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
-        <td>12%</td>
-        <td>15%</td>
+        <td class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.over") %> &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
+        <td class="mortgagecalc__table__rate">12%</td>
+        <td class="mortgagecalc__table__extra">15%</td>
       </tr>
     </tbody>
   </table>

--- a/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
@@ -6,6 +6,7 @@
       <tr>
         <th><%= I18n.t("stamp_duty.table.property_price_header") %></th>
         <th><%= I18n.t("stamp_duty.table.rate_header") %></th>
+        <th><%= I18n.t("stamp_duty.table.extra_rate_header") %></th>
       </tr>
     </thead>
 
@@ -13,27 +14,34 @@
       <tr>
         <td>&pound;0 - &pound;125,000</td>
         <td>0%</td>
+        <td>3%</td>
       </tr>
 
       <tr>
         <td>&pound;125,001 - &pound;250,000</td>
         <td>2%</td>
+        <td>5%</td>
       </tr>
 
       <tr>
         <td>&pound;250,001 - &pound;925,000</td>
         <td>5%</td>
+        <td>8%</td>
       </tr>
 
       <tr>
         <td>&pound;925,001 - &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
         <td>10%</td>
+        <td>13%</td>
       </tr>
 
       <tr>
         <td><%= I18n.t("stamp_duty.table.over") %> &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
         <td>12%</td>
+        <td>15%</td>
       </tr>
     </tbody>
   </table>
 </div>
+
+<p><%= I18n.t("stamp_duty.how_calculated_extra") %></p>

--- a/app/views/mortgage_calculator/stamp_duties/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step1.html.erb
@@ -1,6 +1,7 @@
 <div class="mortgagecalc__panel mortgagecalc__panel--full">
   <div class="intro"><%= I18n.t('stamp_duty.title') %></div>
   <p class="mortgagecalc__intro"><%= I18n.t('stamp_duty.subtitle') %></p>
+  <p class="mortgagecalc__intro"><%= I18n.t('stamp_duty.subtitle_legislation_change') %></p>
   <p class="mortgagecalc__intro">
      <%= I18n.t('stamp_duty.second_subtitle') %>
      <%= link_to t('stamp_duty.href_second_subtitle'), t('stamp_duty.url_second_subtitle') %>

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -10,6 +10,7 @@ cy:
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl"
     second_subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy. Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
     subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy."
+    subtitle_legislation_change: "O 1 Ebrill 2016 bydd unrhyw un sy’n prynu cartref ychwanegol neu eiddo prynu i osod yn gorfod talu  3% yn rhagor ar ben pob band treth stamp."
     second_subtitle: "Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
     href_second_subtitle: "Cyfrifwch yr LBTT sy’n daladwy"
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
@@ -19,7 +20,8 @@ cy:
     recalculate: Ailgyfrifo
     back: "Yn ôl"
     how_calculated_toggle: "Sut y cyfrifir hyn?"
-    how_calculated: "Dan y rheolau newydd o 4 Rhagfyr, cewch dalu Treth Stamp ar amryw o wahanol gyfraddau, yn ddibynnol ar y pris prynu. Dan yr hen reolau, roedd amryw o wahanol gyfraddau o Dreth Stamp, ond roeddech chi, fel prynwr cartref, yn talu'r un gyfradd ar y pris prynu cyfan."
+    how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n prynu eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp. Yn ogystal, o fis Ebrill 2016 bydd landlordiaid ac unrhyw un sy’n prynu cartref ychwanegol yn talu ffi o 3% ychwanegol, sef £6,000 yn yr achos hwn."
+    how_calculated_extra: "* Nid yw’r gyfrifiannell treth stamp yn ystyried y ffi ychwanegol o 3% ar gyfer pryniant Prynu i Werthu neu ail gartrefi."
     describe_price_field: Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn.
     activemodel:
       attributes:
@@ -37,6 +39,7 @@ cy:
     table:
       property_price_header: "Pris Prynu"
       rate_header: "Cyfradd treth stamp"
+      extra_rate_header: "Cyfradd Prynu i Werthu neu Gartref Ychwanegol (o Ebrill 2016) *"
       over: Dros
       million: miliwn
     next_steps:

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -15,7 +15,7 @@ cy:
     href_second_subtitle: "Cyfrifwch yr LBTT sy’n daladwy"
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
     legislation_change: "Cyn 4 Rhagfyr 2014, roeddech yn talu Treth Stamp ar un gyfradd ar y pris prynu cyfan. Os bu i chi gyfnewid cytundebau erbyn hanner nos ar 3 Rhagfyr a chwblhau'r trafodion ar 4 Rhagfyr neu'n hwyrach, gallwch ddewis talu Treth Stamp ar yr hen gyfraddau neu'r rhai newydd."
-    page_2_description: "Treth stamp yw treth ar gost eiddo dros £125,000. Bydd y gyfradd a dalwch yn dibynnu ar bris prynu’ch cartref. Newidiwyd y cyfraddau ar 4 Rhagfyr."
+    page_2_description: "Treth stamp yw treth ar gost eiddo dros £125,000. Bydd y gyfradd a dalwch yn dibynnu ar bris prynu’ch cartref."
     next: "Nesaf"
     recalculate: Ailgyfrifo
     back: "Yn ôl"

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -14,7 +14,7 @@ en:
     href_second_subtitle: "Calculate the LBTT payable."
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
     legislation_change: "Before 4 December 2014, you paid Stamp Duty at a single rate on the whole purchase price. If you exchanged contracts by midnight on 3 December and the transaction completes on 4 December or later, you can choose whether you pay Stamp Duty at the old or new rates."
-    page_2_description: "Stamp Duty is a tax on the cost of properties over £125,000. The rate you pay depends on the purchase price of the property. The rates were changed on December 4. "
+    page_2_description: "Stamp Duty is a tax on the cost of properties over £125,000. The rate you pay depends on the purchase price of the property."
     next: Next
     recalculate: Recalculate
     back: Back

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -9,6 +9,7 @@ en:
     h1: Stamp Duty calculator
     title: Calculate the Stamp Duty on your residential property
     subtitle: "Calculate the Stamp Duty on your residential property in England, Wales or Northern Ireland. You have to pay Stamp Duty (SDLT) if you buy a property costing more than £125,000. Use this calculator to work out how much Stamp Duty is payable."
+    subtitle_legislation_change: "From the 1st April 2016 anyone purchasing an additional home or a buy to let property will have to pay an extra 3% on top of each stamp duty band."
     second_subtitle: "If you live in Scotland, Stamp Duty has now been abolished but you may need to pay a Land and Buildings Transaction Tax (LBTT)."
     href_second_subtitle: "Calculate the LBTT payable."
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
@@ -18,7 +19,8 @@ en:
     recalculate: Recalculate
     back: Back
     how_calculated_toggle: "How is this calculated?"
-    how_calculated: "Under the new rules from 4 December, you may pay Stamp Duty at several different rates, depending on the purchase price. Under the old rules, there were several different Stamp Duty rates, but you, as a homebuyer, paid the same rate on the whole purchase price."
+    how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400. In addition, from April 2016 landlords and anyone buying an additional home will pay an extra 3% charge, in this case £6000."
+    how_calculated_extra: "* The stamp duty calculator does not take into account the additional 3% charge for Buy To Let or secondary home purchases."
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:
       attributes:
@@ -36,6 +38,7 @@ en:
     table:
       property_price_header: "Purchase price of property"
       rate_header: "Rate of Stamp Duty"
+      extra_rate_header: "Buy to Let/ Additional Home Rate (from April 2016) *"
       over: Over
       million: million
     next_steps:


### PR DESCRIPTION
On Oct 25th, the chancellor announced higher stamp duty rates for people buying a house as a second home or to let, from April 2016. Add content to reflect that.