### PR TITLE
[DEV APPROVED] 7014 - Stamp Duty text toggle link fix

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/controllers/calculator.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/controllers/calculator.js
@@ -61,16 +61,18 @@ App.controller('CalculatorCtrl', ['$scope', 'Affordability', 'StampDuty', 'Repay
     $scope.preventFormSubmission = function($event) {
       $event.preventDefault();
     };
-    $scope.expandedRepaymentMortgageInformation = false;
+    $scope.toggleStampDutyExpanded = function($event) {
+      $event.preventDefault();
+      $scope.expandedStampDutyInformation = !$scope.expandedStampDutyInformation;
+    };
     $scope.toggleRepaymentExpanded = function($event) {
       $event.preventDefault();
       $scope.expandedRepaymentMortgageInformation = !$scope.expandedRepaymentMortgageInformation;
     };
-    $scope.expandedInterestMortgageInformation = false;
     $scope.toggleInterestExpanded = function($event) {
       $event.preventDefault();
       $scope.expandedInterestMortgageInformation = !$scope.expandedInterestMortgageInformation;
-    }
+    };
 
     $scope.expandedIntroText = false;
     $scope.toggleIntroExpanded = function($event) {

--- a/app/assets/javascripts/mortgage_calculator/angular/controllers/calculator.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/controllers/calculator.js
@@ -61,14 +61,20 @@ App.controller('CalculatorCtrl', ['$scope', 'Affordability', 'StampDuty', 'Repay
     $scope.preventFormSubmission = function($event) {
       $event.preventDefault();
     };
+
+    $scope.expandedStampDutyInformation = false;
     $scope.toggleStampDutyExpanded = function($event) {
       $event.preventDefault();
       $scope.expandedStampDutyInformation = !$scope.expandedStampDutyInformation;
     };
+
+    $scope.expandedRepaymentMortgageInformation = false;
     $scope.toggleRepaymentExpanded = function($event) {
       $event.preventDefault();
       $scope.expandedRepaymentMortgageInformation = !$scope.expandedRepaymentMortgageInformation;
     };
+
+    $scope.expandedInterestMortgageInformation = false;
     $scope.toggleInterestExpanded = function($event) {
       $event.preventDefault();
       $scope.expandedInterestMortgageInformation = !$scope.expandedInterestMortgageInformation;

--- a/app/views/mortgage_calculator/stamp_duties/_calc_right_panel.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_calc_right_panel.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <p>
-    <a href="#" class="rendered-from-js expander expander--nudge" ng-class="{ 'expander--expanded' : expandedMortgageInformation }" ng-click="toggleExpanded($event)" affects-height="click">
+    <a href="#" class="rendered-from-js expander expander--nudge" ng-class="{ 'expander--expanded' : expandedStampDutyInformation }" ng-click="toggleStampDutyExpanded($event)" affects-height="click">
       <%= I18n.t("stamp_duty.how_calculated_toggle") %>
       <span class="visually-hidden"><%= I18n.t("stamp_duty.results.click_to_expand") %></span>
     </a>

--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_tip.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_tip.html.erb
@@ -1,5 +1,5 @@
 <div class="mortgagecalc__panel mortgagecalc__panel--full">
-  <div ng-show="expandedMortgageInformation" class="mortgagecalc__tip">
+  <div ng-show="expandedStampDutyInformation" class="mortgagecalc__tip">
     <%= render 'bands_table' %>
   </div>
 </div>


### PR DESCRIPTION
Fixes a regression issue with the Stamp Duty calculator. When clicking 'How it is calculated' the visibility of a text section needs to be toggled.