### PR TITLE
Fixing path to background image for expander

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_expander.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_expander.scss
@@ -4,7 +4,7 @@
 
 .expander__link {
   display: inline-block;
-  background: url(/assets/mortgage_calculator/expander.png) 0 0 no-repeat;
+  background: image_url('mortgage_calculator/expander.png') 0 0 no-repeat;
   padding-left: 30px;
   font-size:0.875em;
 


### PR DESCRIPTION
The expander logo uses a background image. This works locally, but not on any deployed environment - Production receives a 404 error when requesting the expander.png file from the CDN, as the path was wrong.
 
Production (before fix):

![image](https://cloud.githubusercontent.com/assets/14920201/13075738/65e7abd2-d4a5-11e5-9500-fb67223e94e7.png)


Localhost:

![image](https://cloud.githubusercontent.com/assets/14920201/13075704/27e9df12-d4a5-11e5-97c1-99b464b4dbba.png)


 
