### PR TITLE
[DEV APPROVED] #7030 - Mortgage Calculator Screen Reader

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/controllers/calculator.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/controllers/calculator.js
@@ -45,6 +45,7 @@ App.controller('CalculatorCtrl', ['$scope', 'Affordability', 'StampDuty', 'Repay
       $event.preventDefault();
       $scope.viewMonthlyRepayments = true;
       $scope.viewInterestRepayments = false;
+      $scope.tabSelector();
 
       window.focusElementForScreenReaders($('#panel__monthly_repayments').first());
     };
@@ -53,6 +54,7 @@ App.controller('CalculatorCtrl', ['$scope', 'Affordability', 'StampDuty', 'Repay
       $event.preventDefault();
       $scope.viewMonthlyRepayments = false;
       $scope.viewInterestRepayments = true;
+      $scope.tabSelector();
 
       window.focusElementForScreenReaders($('#panel__interest_repayments').first());
     };
@@ -117,6 +119,23 @@ App.controller('CalculatorCtrl', ['$scope', 'Affordability', 'StampDuty', 'Repay
     $scope.dockerControl = {};
     $scope.dockerReady = false;
     $scope.docked = false;
+
+    // Apply selected attributes to repayment tabs
+    $scope.tabSelector = function($event) {
+      if($scope.viewMonthlyRepayments) {
+        $('.payment_tab').attr('aria-selected', 'false').removeAttr('selected');
+        $('.payment_tab:first-child').attr({
+          'aria-selected' : 'true',
+          'selected' : 'selected'
+        });
+      } else {
+        $('.payment_tab').attr({
+          'aria-selected' : 'true',
+          'selected' : 'selected'
+        });
+        $('.payment_tab:first-child').attr('aria-selected', 'false').removeAttr('selected');
+      };
+    };
 
     iframeHelpers.resizeIframe();
   }]);

--- a/app/views/mortgage_calculator/repayments/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/repayments/_form_step2.html.erb
@@ -1,4 +1,7 @@
 <%= form_for @repayment, url: repayment_path, html: { class: 'form step_two mortgagecalc__form', id: 'edit_repayment', novalidate: ''} do |f| %>
+
+  <h3 class="visually-hidden"><%= I18n.t("mortgage_calculator.repayment.step_2.hidden_title") %></h3>
+
   <div class="form__item">
     <%= f.label :price,
     	"id" => "label_price" %>

--- a/app/views/mortgage_calculator/repayments/_interest_only_repayments.html.erb
+++ b/app/views/mortgage_calculator/repayments/_interest_only_repayments.html.erb
@@ -1,3 +1,8 @@
 <p ng-hide="js" class="mortgagecalc__heading mortgagecalc__payment squeeze"><%= number_to_currency @interest_only.monthly_payment %></p>
-<p class="rendered-from-js mortgagecalc__heading mortgagecalc__payment squeeze">{{ repayments.monthlyInterestRepayment() | customCurrency:"£" }}</p>
-<p class="squeeze"><strong><%= I18n.t("mortgage_calculator.repayment.a_month") %></strong></p>
+<div aria-live="polite" aria-atomic="true">
+  <p class="visually-hidden"><%= I18n.t("mortgage_calculator.repayment.tabs.interest_only.hidden_title") %></p>
+  <p class="rendered-from-js mortgagecalc__heading mortgagecalc__payment squeeze">
+    {{ repayments.monthlyInterestRepayment() | customCurrency:"£" }}
+  </p>
+  <p class="squeeze"><strong><%= I18n.t("mortgage_calculator.repayment.a_month") %></strong></p>
+</div>

--- a/app/views/mortgage_calculator/repayments/_monthly_repayments.html.erb
+++ b/app/views/mortgage_calculator/repayments/_monthly_repayments.html.erb
@@ -1,3 +1,8 @@
-  <p ng-hide="js" class="mortgagecalc__heading mortgagecalc__payment squeeze"><%= number_to_currency @repayment.monthly_payment %></p>
-  <p class="rendered-from-js mortgagecalc__heading mortgagecalc__payment squeeze">{{ repayments.monthlyRepayment() | customCurrency:"£" }}</p>
-  <p class="squeeze"><strong><%= I18n.t("mortgage_calculator.repayment.a_month") %></strong></p>
+<p ng-hide="js" class="mortgagecalc__heading mortgagecalc__payment squeeze"><%= number_to_currency @repayment.monthly_payment %></p>
+<div aria-live="polite" aria-atomic="true">
+  <p class="visually-hidden"><%= I18n.t("mortgage_calculator.repayment.tabs.repayment.hidden_title") %></p>
+  <p class="rendered-from-js mortgagecalc__heading mortgagecalc__payment squeeze">
+    {{ repayments.monthlyRepayment() | customCurrency:"£" }}
+  </p>
+  <span class="squeeze" aria-live="polite"><strong><%= I18n.t("mortgage_calculator.repayment.a_month") %></strong></span>
+</div>

--- a/app/views/mortgage_calculator/repayments/_tabs.html.erb
+++ b/app/views/mortgage_calculator/repayments/_tabs.html.erb
@@ -1,28 +1,28 @@
 <div class="tabs">
-      <dl class="tabs__list rendered-from-js">
-        <dt><a href="#" class="tabs__link" ng-click="showMonthly($event)" ng-class="{ 'tabs__current' : viewMonthlyRepayments }"><%= I18n.t("mortgage_calculator.repayment.tabs.repayment.title") %></a></dt>
-        <dt><a href="#" class="tabs__link" ng-click="showInterest($event)" ng-class="{ 'tabs__current' : viewInterestRepayments }"><%= I18n.t("mortgage_calculator.repayment.tabs.interest_only.title") %></a></dt>
-      </dl>
-      <div class="tabs__content">
-        <div class="tabs__panel" ng-show="viewMonthlyRepayments" id="panel__monthly_repayments">
-          <h3 class="subheading hide-with-js"><%= I18n.t("mortgage_calculator.repayment.tabs.repayment.title") %></h3>
-          <%= render 'monthly_repayments' %>
-          <div class="expander">
-            <a href="#" class="rendered-from-js expander__link" ng-class="{ 'expander__link--expanded' : expandedRepaymentMortgageInformation }" ng-click="toggleRepaymentExpanded($event)"><%= I18n.t("mortgage_calculator.repayment.tabs.repayment.explain") %></a>
-          </div>
-          <div ng-show="expandedRepaymentMortgageInformation" class="mortgagecalc__tip">
-            <%= render 'repayment_tip' %>
-          </div>
-        </div>
-        <div class="tabs__panel" ng-show="viewInterestRepayments" id="panel__interest_repayments">
-          <h3 class="subheading hide-with-js"><%= I18n.t("mortgage_calculator.repayment.tabs.interest_only.title") %></h3>
-          <%= render 'interest_only_repayments' %>
-          <div class="expander">
-            <a href="#" class="rendered-from-js expander__link" ng-class="{ 'expander__link--expanded' : expandedInterestMortgageInformation }" ng-click="toggleInterestExpanded($event)"><%= I18n.t("mortgage_calculator.repayment.tabs.interest_only.explain") %></a>
-          </div>
-          <div ng-show="expandedInterestMortgageInformation" class="mortgagecalc__tip">
-            <%= render 'interest_only_repayment_tip' %>
-          </div>
-        </div>
+  <dl class="tabs__list rendered-from-js" role="tablist">
+    <dt role="tab" class="payment_tab" aria-selected="true" selected="selected" ng-click="showMonthly($event)"><a href="#" class="tabs__link" ng-class="{ 'tabs__current' : viewMonthlyRepayments }"><%= I18n.t("mortgage_calculator.repayment.tabs.repayment.title") %></a></dt>
+    <dt role="tab" class="payment_tab" ng-click="showInterest($event)"><a href="#" class="tabs__link" ng-class="{ 'tabs__current' : viewInterestRepayments }"><%= I18n.t("mortgage_calculator.repayment.tabs.interest_only.title") %></a></dt>
+  </dl>
+  <div class="tabs__content">
+    <div class="tabs__panel" ng-show="viewMonthlyRepayments" id="panel__monthly_repayments">
+      <h3 class="subheading hide-with-js"><%= I18n.t("mortgage_calculator.repayment.tabs.repayment.title") %></h3>
+      <%= render 'monthly_repayments' %>
+      <div class="expander">
+        <a href="#" class="rendered-from-js expander__link" ng-class="{ 'expander__link--expanded' : expandedRepaymentMortgageInformation }" ng-click="toggleRepaymentExpanded($event)"><%= I18n.t("mortgage_calculator.repayment.tabs.repayment.explain") %></a>
+      </div>
+      <div ng-show="expandedRepaymentMortgageInformation" class="mortgagecalc__tip">
+        <%= render 'repayment_tip' %>
       </div>
     </div>
+    <div class="tabs__panel" ng-show="viewInterestRepayments" id="panel__interest_repayments">
+      <h3 class="subheading hide-with-js"><%= I18n.t("mortgage_calculator.repayment.tabs.interest_only.title") %></h3>
+      <%= render 'interest_only_repayments' %>
+      <div class="expander">
+        <a href="#" class="rendered-from-js expander__link" ng-class="{ 'expander__link--expanded' : expandedInterestMortgageInformation }" ng-click="toggleInterestExpanded($event)"><%= I18n.t("mortgage_calculator.repayment.tabs.interest_only.explain") %></a>
+      </div>
+      <div ng-show="expandedInterestMortgageInformation" class="mortgagecalc__tip">
+        <%= render 'interest_only_repayment_tip' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/mortgage_calculator.cy.yml
+++ b/config/locales/mortgage_calculator.cy.yml
@@ -35,17 +35,20 @@ cy:
       step_2:
         intro_html: |
           <p>Mae hyn yn ganllaw i faint fyddech yn talu pob mis. Yna symudwch y llithrwyr i newid y cyfnod i gydfynd â’r nifer o flynyddoedd sydd gennych yn weddill i dalu, a chynyddwch y gyfradd llog. Bydd yr union swm yn dibynnu ar y math o forgais a’r darparwr benthyciadau.</p>
+        hidden_title: Addaswch y manylion
       tabs:
         repayment:
           explain: Beth mae hyn yn ei gynnwys?
           title: Ad-daliad
           tip_1: "Rydych yn ad-dalu'r swm yr ydych wedi ei fenthyca, a'r llog"
+          hidden_title: Bydd eich ad-daliadau yn
         interest_only:
           explain: Gwybodaeth bwysig
           title: Llog yn unig
           tip_1: Golyga’r rheoliadau diweddaraf y bydd angen i chi a’ch darparwr benthyciadau gytuno ar gynllun ad-dalu ar gyfer eich morgais.
           tip_1_linktext: Darllenwch fwy
           tip_1_url: /cy/articles/dulliau-ad-dalu-morgais-llog-yn-unig
+          hidden_title: Eich diddordeb yn unig ad-daliadau
       tips:
         hidden_costs: Cofiwch gynllunio ar gyfer costau eraill fel ffioedd morgais, ffioedd cyfreithiol a threth stamp.
       interest_changer:

--- a/config/locales/mortgage_calulator.en.yml
+++ b/config/locales/mortgage_calulator.en.yml
@@ -35,17 +35,20 @@ en:
       step_2:
         intro_html: |
           <p>This is a guide to how much you'd pay each month. Adjust the sliders to change the term to the number of years you have left to pay, and increase the interest rate. The exact amount will depend on the type of mortgage and the lender.</p>
+        hidden_title: Adjust details
       tabs:
         repayment:
           explain: "What does this mean?"
           title: Repayment
           tip_1: "You pay off what you borrowed for the mortgage, plus the interest."
+          hidden_title: Your repayments will be
         interest_only:
           explain: "Important information"
           title: Interest Only
           tip_1: The latest regulations mean you and your lender will need to agree a repayment plan for your mortgage.
           tip_1_linktext: Read more
           tip_1_url: /en/articles/ways-of-repaying-an-interest-only-mortgage
+          hidden_title: Your interest only repayments will be
       tips:
         hidden_costs: Remember to plan for other costs like mortgage fees, legal fees and Stamp Duty tax.
       interest_changer:


### PR DESCRIPTION
## 7030 - Mortgage Calculator - Repayments not read out by screen reader

### Tabs
Altering tabs so they appear as tabs to the screen reader, and show you which is selected, and also how many tabs there are.  Repayment tab has attribute ``aria-selected="true"`` by default, which changes when tabs are clicked.

| Before | After |
|----------|--------|
|<img width="335" alt="screen shot 2016-02-24 at 13 05 51" src="https://cloud.githubusercontent.com/assets/13165846/13286183/717f0aaa-daf7-11e5-931c-da81b800e389.png">|<img width="326" alt="screen shot 2016-02-24 at 13 04 52" src="https://cloud.githubusercontent.com/assets/13165846/13286187/77c36870-daf7-11e5-9ce6-176a94efe708.png">|

### Updating monthly payment
Wrapping the monthly repayment information in a container with the properties ``aria-live="polite" aria-atomic="true"`` and including hidden text makes the updating of values easier for a screen reader user to follow, with this change when the user updates the values in the right column (and when the user is idle), the screen reader will then read the hidden text, then the value, then the frequency (monthly)

| Repayment | Interest Only |
|----------|--------|
|<img width="648" alt="repayment" src="https://cloud.githubusercontent.com/assets/13165846/13524109/2ff443c4-e1f1-11e5-97d2-4d3de6d7280b.png">|<img width="716" alt="interest only" src="https://cloud.githubusercontent.com/assets/13165846/13524115/3919f94e-e1f1-11e5-83c8-6aa381f358de.png">|

### Adjust details heading
An visually invisible heading has also been added before the ability to adjust the values on step 2 immediately before the adjustable sliders:

<img width="623" alt="screen shot 2016-02-24 at 13 16 28" src="https://cloud.githubusercontent.com/assets/13165846/13286415/21a48e0e-daf9-11e5-8d0a-3a07a850afa7.png">