### PR TITLE
[DEV APPROVED]Adding option to calculate for a second (or buy-to-let) home (#247)

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
@@ -1,8 +1,12 @@
 'use strict';
 
 App.factory('StampDuty', function() {
+    var SECOND_HOME_TAX_THRESHOLD = 40000
+      , SECOND_HOME_TAX_RATE = 3;
+
     var stampDuty = {
       propertyPrice : 0,
+      isSecondHome: false,
       rates: [
         {
           threshold: 125000,
@@ -47,6 +51,10 @@ App.factory('StampDuty', function() {
           if (remaining < 0) {
             break;
           }
+        }
+
+        if (this.isSecondHome && this.propertyPrice >= SECOND_HOME_TAX_THRESHOLD) {
+          totalTax += this.propertyPrice * (SECOND_HOME_TAX_RATE / 100);
         }
 
         return totalTax;

--- a/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
@@ -55,8 +55,15 @@
 
 .mortgagecalc__panel {
   @include column(12);
+
   @include respond-to($mortgagecalc_mq-s) {
     @include column(6);
+  }
+
+  .step_one & {
+    @include respond-to($mortgagecalc_mq-s) {
+      @include column(12);
+    }
   }
 
   &.mortgagecalc__panel--full {
@@ -170,5 +177,11 @@
     display: inline-block;
     width: auto;
     width: min-content;
+  }
+}
+
+.form__input-container--pulled {
+  @include respond-to($mortgagecalc_mq-s) {
+    width: 50%;
   }
 }

--- a/app/assets/stylesheets/mortgage_calculator/lib/_utils.scss
+++ b/app/assets/stylesheets/mortgage_calculator/lib/_utils.scss
@@ -3,3 +3,11 @@ $responsive: true !default;
 .is-hidden {
   display:none;
 }
+
+.hidden-unless-js {
+  display: none;
+
+  .js & {
+    display: inherit;
+  }
+}

--- a/app/models/mortgage_calculator/stamp_duty.rb
+++ b/app/models/mortgage_calculator/stamp_duty.rb
@@ -17,7 +17,11 @@ module MortgageCalculator
       1000000000 => 12
     }
 
+    SECOND_HOME_THRESHOLD = 40000
+    SECOND_HOME_RATE = 3.0
+
     attr_reader :price
+    attr_accessor :second_home
 
     currency_inputs :price
 
@@ -25,6 +29,7 @@ module MortgageCalculator
 
     def initialize(options = {})
       self.price = options.fetch(:price){ 0 }
+      self.second_home = options.key?(:second_home) && options[:second_home] == "true"
     end
 
     [:price, :tax_due, :total_due].each do |field|
@@ -45,6 +50,10 @@ module MortgageCalculator
         total_tax = total_tax + (band_taxable * rate/100)
         remaining -= bandwidth
         break if remaining < 0
+      end
+
+      if self.second_home && price >= SECOND_HOME_THRESHOLD
+        total_tax += price * (SECOND_HOME_RATE / 100)
       end
 
       total_tax

--- a/app/views/mortgage_calculator/stamp_duties/_calc_right_panel.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_calc_right_panel.html.erb
@@ -2,7 +2,16 @@
   <div class="tabs">
     <div class="tabs__content">
       <div class="tabs__panel">
-        <h2 class="callout__heading"><%= I18n.t("stamp_duty.results.title") %>:</h2>
+        <h2 class="callout__heading">
+          <div ng-hide="js">
+            <% key = @stamp_duty.second_home ? 'second_title' : 'title' %>
+            <%= I18n.t("stamp_duty.results.#{key}") %>
+          </div>
+          <div class="hidden-unless-js">
+            <span ng-if="stampDuty.isSecondHome"><%= I18n.t("stamp_duty.results.second_title") %></span>
+            <span ng-if="!stampDuty.isSecondHome"><%= I18n.t("stamp_duty.results.title") %></span>
+          </div>
+        </h2>
         <%= render 'stamp_duty_payment' %>
       </div>
     </div>

--- a/app/views/mortgage_calculator/stamp_duties/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step1.html.erb
@@ -14,7 +14,7 @@
       <%= f.label :price %>
       <div class="visually-hidden" id="mc_accessibility_describe_price"><%= t 'stamp_duty.describe_price_field' %></div>
 
-      <span class="form__input-container">
+      <span class="form__input-container form__input-container--pulled">
         <span class="form__input-label">£</span>
         <%= f.text_field :price,
                          :value => @stamp_duty.price_formatted,
@@ -28,6 +28,12 @@
         <span class="form__input-outline"></span>
       </span>
 
+    </div>
+    <div class="form__item">
+      <label class="label--accent">
+        <%= f.check_box :second_home, {'ng-model' => 'stampDuty.isSecondHome'}, 'true', 'false' %>
+        <%= I18n.t('stamp_duty.second_home.label') %>
+      </label>
     </div>
   </div>
 

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -6,7 +6,10 @@
 <%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_two mortgagecalc__form mortgagecalc__form--pull', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
   <div class="form__item">
     <%= f.label :price %>
-    <div class="visually-hidden" id="mc_accessibility_describe_price"><%= t 'stamp_duty.describe_price_field' %></div>
+    <div class="visually-hidden"
+          id="mc_accessibility_describe_price">
+      <%= t 'stamp_duty.describe_price_field' %>
+    </div>
 
     <span class="form__input-container">
       <span class="form__input-label">£</span>
@@ -28,8 +31,17 @@
                        %>
       <span class="form__input-outline"></span>
     </span>
+  </div>
+  <%= f.hidden_field :second_home %>
 
-    <div class="slider" ui-slider dynamic-for='dynamic-slider-property' ng-model="stampDuty.propertyPrice" analytics-category="Stamp Duty" analytics-action="Refinement" analytics-label="Price" aria-hidden="true"></div>
+  <div class="slider"
+        ui-slider
+        dynamic-for='dynamic-slider-property'
+        ng-model="stampDuty.propertyPrice"
+        analytics-category="Stamp Duty"
+        analytics-action="Refinement"
+        analytics-label="Price"
+        aria-hidden="true">
   </div>
 
   <div class="hide-with-js">

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -10,9 +10,9 @@ cy:
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl"
     second_subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy. Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
     subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy."
-    subtitle_legislation_change: "O 1 Ebrill 2016 bydd unrhyw un sy’n prynu cartref ychwanegol neu eiddo prynu i osod yn gorfod talu  3% yn rhagor ar ben pob band treth stamp."
-    second_subtitle: "Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
-    href_second_subtitle: "Cyfrifwch yr LBTT sy’n daladwy"
+    subtitle_legislation_change: "O 1 Ebrill 2016 bydd unrhyw un sy'n prynu cartref ychwanegol gan gynnwys eiddo prynu i osod yn gorfod talu ffi ychwanegol o 3% ar ben pob band treth stamp."
+    second_subtitle: "Mae Treth Trafodion Tir ac Adeiladau (LBTT) wedi disodli Treth Stamp yn yr Alban. Bydd trethi LBTT yn destun ffi ychwanegol o 3% hefyd ar gyfer ail gartrefi o fis Ebrill 2016 ymlaen."
+    href_second_subtitle: "Cyfrifwch yr LBTT sy'n daladwy"
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
     legislation_change: "Cyn 4 Rhagfyr 2014, roeddech yn talu Treth Stamp ar un gyfradd ar y pris prynu cyfan. Os bu i chi gyfnewid cytundebau erbyn hanner nos ar 3 Rhagfyr a chwblhau'r trafodion ar 4 Rhagfyr neu'n hwyrach, gallwch ddewis talu Treth Stamp ar yr hen gyfraddau neu'r rhai newydd."
     page_2_description: "Treth stamp yw treth ar gost eiddo dros £125,000. Bydd y gyfradd a dalwch yn dibynnu ar bris prynu’ch cartref."
@@ -20,9 +20,9 @@ cy:
     recalculate: Ailgyfrifo
     back: "Yn ôl"
     how_calculated_toggle: "Sut y cyfrifir hyn?"
-    how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n prynu eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp."
-    how_calculated_additional: "O fis Ebrill 2016, bydd unrhyw un sy’n prynu ail gartref yn talu 3% ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny’n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750."
-    how_calculated_extra: "* Nid yw’r gyfrifiannell treth stamp yn ystyried y ffi ychwanegol o 3% ar gyfer pryniant Prynu i Werthu neu ail gartrefi."
+    how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n prynu eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp gan roi cyfradd dreth effeithiol o 1%."
+    how_calculated_additional: "O fis Ebrill 2016, bydd unrhyw un sy'n prynu ail gartref, gan gynnwys eiddo prynu i osod, yn talu 3% ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny'n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750, gan roi cyfradd dreth effeithiol o 4%."
+    how_calculated_extra: "Nid yw eiddo dan £40,000 yn destun SDLT ail gartref"
     describe_price_field: Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn.
     activemodel:
       attributes:
@@ -33,10 +33,13 @@ cy:
       one: "Mae'r gyfrifiannell hon yn ganllaw yn unig i dreth stamp ar eiddo preswyl. Mae gwahanol gyfraddau'n gymwys ar gyfer eiddo nad yw'n eiddo preswyl."
     results:
       title: "Y dreth stamp i'w thalu yw"
+      second_title: "Treth Stamp ar eich eiddo ychwanegol"
       sentence: "Y gyfradd dreth effeithiol yw %{percentage}"
       sentence_prefix: "Y gyfradd dreth effeithiol yw"
       sentence_suffix: "%"
       click_to_expand: Cliciwch i ehangu
+    second_home:
+      label: Cyfrifwch y Dreth Stamp ar unrhyw eiddo prynu i osod ychwanegol.
     table:
       property_price_header: "Pris Prynu"
       rate_header: "Cyfradd treth stamp"

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -39,7 +39,7 @@ cy:
       sentence_suffix: "%"
       click_to_expand: Cliciwch i ehangu
     second_home:
-      label: Cyfrifwch y Dreth Stamp ar unrhyw eiddo prynu i osod ychwanegol.
+      label: Cyfrifwch y Dreth Stamp ar eiddo ychwanegol ac eiddo prynu i osod.
     table:
       property_price_header: "Pris Prynu"
       rate_header: "Cyfradd treth stamp"

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -9,8 +9,8 @@ en:
     h1: Stamp Duty calculator
     title: Calculate the Stamp Duty on your residential property
     subtitle: "Calculate the Stamp Duty on your residential property in England, Wales or Northern Ireland. You have to pay Stamp Duty (SDLT) if you buy a property costing more than £125,000. Use this calculator to work out how much Stamp Duty is payable."
-    subtitle_legislation_change: "From the 1st April 2016 anyone purchasing an additional home or a buy to let property will have to pay an extra 3% on top of each stamp duty band."
-    second_subtitle: "If you live in Scotland, Stamp Duty has now been abolished but you may need to pay a Land and Buildings Transaction Tax (LBTT)."
+    subtitle_legislation_change: "From the 1st April 2016 anyone purchasing an additional home including buy to let properties will have to pay an extra 3% surcharge on top of each stamp duty band."
+    second_subtitle: "Land and Buildings Transaction Tax (LBTT) has replaced Stamp Duty in Scotland. LBTT rates will also attract a 3% surcharge for second homes from 1st April 2016."
     href_second_subtitle: "Calculate the LBTT payable."
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
     legislation_change: "Before 4 December 2014, you paid Stamp Duty at a single rate on the whole purchase price. If you exchanged contracts by midnight on 3 December and the transaction completes on 4 December or later, you can choose whether you pay Stamp Duty at the old or new rates."
@@ -19,9 +19,9 @@ en:
     recalculate: Recalculate
     back: Back
     how_calculated_toggle: "How is this calculated?"
-    how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400."
-    how_calculated_additional: "As of April 2016, anyone buying a second home will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750."
-    how_calculated_extra: "* The stamp duty calculator does not take into account the additional 3% charge for Buy To Let or secondary home purchases."
+    how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400 giving an effective tax rate of 1%."
+    how_calculated_additional: "As of April 2016, anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
+    how_calculated_extra: "Properties under £40,000 are not subject to second home SDLT"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:
       attributes:
@@ -32,10 +32,13 @@ en:
       one: "This calculator is a guide only to Stamp Duty on residential properties. Different rates apply to properties for non-residential use."
     results:
       title: "Stamp Duty to pay is"
+      second_title: "Stamp Duty on your additional property"
       sentence: "The effective tax rate is %{percentage}"
       sentence_prefix: "The effective tax rate is"
       sentence_suffix: "%"
       click_to_expand: Click to expand.
+    second_home:
+      label: Calculate the Stamp Duty on additional and buy to let property.
     table:
       property_price_header: "Purchase price of property"
       rate_header: "Rate of Stamp Duty"

--- a/features/stamp_duty.feature
+++ b/features/stamp_duty.feature
@@ -12,51 +12,139 @@ Scenario: Welsh users
   Given I visit the Welsh Stamp Duty page
   Then  I see the Welsh stamp duty calculator
 
-Scenario: House price which is less than £125,000
+Scenario: House price which is less than £40,000 for first home
   Given I visit the Stamp Duty page
-  When I enter my house price with "120000"
+  When I enter my house price with "39000"
+  And I click next
   Then I see the stamp duty I will have to pay is "£0"
 
-Scenario: House price which is over £125,000
+Scenario: House price which is less than £40,000 for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "39000"
+  And I select to calculate for a second home
+  And I click next
+  Then I see the stamp duty I will have to pay is "£0"
+
+Scenario: House price which is equal to £40,000 for first home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "40000"
+  And I click next
+  Then I see the stamp duty I will have to pay is "£0"
+
+Scenario: House price which is equal to £40,000 for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "40000"
+  And I select to calculate for a second home
+  And I click next
+  Then I see the stamp duty I will have to pay is "£1,200"
+
+Scenario: House price which is less than £125,000 for first home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "120000"
+  And I click next
+  Then I see the stamp duty I will have to pay is "£0"
+
+Scenario: House price which is less than £125,000 for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "120000"
+  And I select to calculate for a second home
+  And I click next
+  Then I see the stamp duty I will have to pay is "£3,600"
+
+Scenario: House price which is over £125,000 for first home
   Given I visit the Stamp Duty page
   When I enter my house price with "126000"
+  And I click next
   Then I see the stamp duty I will have to pay is "£20"
 
-Scenario: House price which is over £250,000
+Scenario: House price which is over £125,000 for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "126000"
+  And I select to calculate for a second home
+  And I click next
+  Then I see the stamp duty I will have to pay is "3,800"
+
+Scenario: House price which is over £250,000 for first home
   Given I visit the Stamp Duty page
   When I enter my house price with "260000"
+  And I click next
   Then I see the stamp duty I will have to pay is "£3,000"
 
-Scenario: I recalculate
+Scenario: House price which is over £250,000 for second home
   Given I visit the Stamp Duty page
   When I enter my house price with "260000"
+  And I select to calculate for a second home
+  And I click next
+  Then I see the stamp duty I will have to pay is "£10,800"
+
+Scenario: I recalculate for first home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "260000"
+  And I click next
   And I see the stamp duty I will have to pay is "£3,000"
   Then I reenter my house price with "126000"
+  And I click next again
   And I see the stamp duty I will have to pay is "£20"
 
-Scenario: House price which is over £500,000
+Scenario: I recalculate for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "260000"
+  And I select to calculate for a second home
+  And I click next
+  And I see the stamp duty I will have to pay is "£10,800"
+  Then I reenter my house price with "126000"
+  And I click next again
+  And I see the stamp duty I will have to pay is "£3,800"
+
+Scenario: House price which is over £500,000 for first home
   Given I visit the Stamp Duty page
   When I enter my house price with "510000"
+  And I click next
   Then I see the stamp duty I will have to pay is "£15,500"
 
-Scenario: House price which is over £1 million
+Scenario: House price which is over £500,000 for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "510000"
+  And I select to calculate for a second home
+  And I click next
+  Then I see the stamp duty I will have to pay is "£30,800"
+
+Scenario: House price which is over £1 million for first home
   Given I visit the Stamp Duty page
   When I enter my house price with "1100000"
+  And I click next
   Then I see the stamp duty I will have to pay is "£53,750"
 
-Scenario: House price which is over £2 million
+Scenario: House price which is over £1 million for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "1100000"
+  And I select to calculate for a second home
+  And I click next
+  Then I see the stamp duty I will have to pay is "£86,750"
+
+Scenario: House price which is over £2 million for first home
   Given I visit the Stamp Duty page
   When I enter my house price with "2100000"
+  And I click next
   Then I see the stamp duty I will have to pay is "£165,750"
+
+Scenario: House price which is over £2 million for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "2100000"
+  And I select to calculate for a second home
+  And I click next
+  Then I see the stamp duty I will have to pay is "£228,750"
 
 @wip
 Scenario: User enters invalid property price
   Given I visit the Stamp Duty page
   When I enter my house price with "sx"
+  And I click next
   Then they do not see the result output
 
 @wip
 Scenario: User enters 0 as the property price
   Given I visit the Stamp Duty page
   When I enter my house price with "0"
+  And I click next
   Then they do not see the result output

--- a/features/stamp_duty.feature
+++ b/features/stamp_duty.feature
@@ -12,70 +12,40 @@ Scenario: Welsh users
   Given I visit the Welsh Stamp Duty page
   Then  I see the Welsh stamp duty calculator
 
-Scenario: House price which is less than £40,000 for first home
+Scenario Outline: stamp duty for first home
   Given I visit the Stamp Duty page
-  When I enter my house price with "39000"
+  When I enter a house price of <price>
   And I click next
-  Then I see the stamp duty I will have to pay is "£0"
+  Then I see the stamp duty I will have to pay is "£<duty>"
 
-Scenario: House price which is less than £40,000 for second home
+Examples:
+  | price   | duty    |
+  | 39000   | 0       |
+  | 40000   | 0       |
+  | 120000  | 0       |
+  | 126000  | 20      |
+  | 260000  | 3,000   |
+  | 510000  | 15,500  |
+  | 1100000 | 53,750  |
+  | 2100000 | 165,750 |
+
+Scenario Outline: stamp duty for second home
   Given I visit the Stamp Duty page
-  When I enter my house price with "39000"
+  When I enter a house price of <price>
   And I select to calculate for a second home
   And I click next
-  Then I see the stamp duty I will have to pay is "£0"
+  Then I see the stamp duty I will have to pay is "£<duty>"
 
-Scenario: House price which is equal to £40,000 for first home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "40000"
-  And I click next
-  Then I see the stamp duty I will have to pay is "£0"
-
-Scenario: House price which is equal to £40,000 for second home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "40000"
-  And I select to calculate for a second home
-  And I click next
-  Then I see the stamp duty I will have to pay is "£1,200"
-
-Scenario: House price which is less than £125,000 for first home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "120000"
-  And I click next
-  Then I see the stamp duty I will have to pay is "£0"
-
-Scenario: House price which is less than £125,000 for second home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "120000"
-  And I select to calculate for a second home
-  And I click next
-  Then I see the stamp duty I will have to pay is "£3,600"
-
-Scenario: House price which is over £125,000 for first home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "126000"
-  And I click next
-  Then I see the stamp duty I will have to pay is "£20"
-
-Scenario: House price which is over £125,000 for second home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "126000"
-  And I select to calculate for a second home
-  And I click next
-  Then I see the stamp duty I will have to pay is "3,800"
-
-Scenario: House price which is over £250,000 for first home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "260000"
-  And I click next
-  Then I see the stamp duty I will have to pay is "£3,000"
-
-Scenario: House price which is over £250,000 for second home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "260000"
-  And I select to calculate for a second home
-  And I click next
-  Then I see the stamp duty I will have to pay is "£10,800"
+Examples:
+  | price   | duty    |
+  | 39000   | 0       |
+  | 40000   | 1,200   |
+  | 120000  | 3,600   |
+  | 126000  | 3,800   |
+  | 260000  | 10,800  |
+  | 510000  | 30,800  |
+  | 1100000 | 86,750  |
+  | 2100000 | 228,750 |
 
 Scenario: I recalculate for first home
   Given I visit the Stamp Duty page
@@ -95,45 +65,6 @@ Scenario: I recalculate for second home
   Then I reenter my house price with "126000"
   And I click next again
   And I see the stamp duty I will have to pay is "£3,800"
-
-Scenario: House price which is over £500,000 for first home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "510000"
-  And I click next
-  Then I see the stamp duty I will have to pay is "£15,500"
-
-Scenario: House price which is over £500,000 for second home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "510000"
-  And I select to calculate for a second home
-  And I click next
-  Then I see the stamp duty I will have to pay is "£30,800"
-
-Scenario: House price which is over £1 million for first home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "1100000"
-  And I click next
-  Then I see the stamp duty I will have to pay is "£53,750"
-
-Scenario: House price which is over £1 million for second home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "1100000"
-  And I select to calculate for a second home
-  And I click next
-  Then I see the stamp duty I will have to pay is "£86,750"
-
-Scenario: House price which is over £2 million for first home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "2100000"
-  And I click next
-  Then I see the stamp duty I will have to pay is "£165,750"
-
-Scenario: House price which is over £2 million for second home
-  Given I visit the Stamp Duty page
-  When I enter my house price with "2100000"
-  And I select to calculate for a second home
-  And I click next
-  Then I see the stamp duty I will have to pay is "£228,750"
 
 @wip
 Scenario: User enters invalid property price

--- a/features/step_definitions/stamp_duty.rb
+++ b/features/step_definitions/stamp_duty.rb
@@ -26,6 +26,10 @@ When(/^I enter my house price with "(.*?)"$/) do |amount|
   @stamp_duty.property_price.set amount
 end
 
+When(/^I enter a house price of (\d+)$/) do |amount|
+  @stamp_duty.property_price.set amount
+end
+
 When(/^I click next$/) do
   @stamp_duty.next.click
 end

--- a/features/step_definitions/stamp_duty.rb
+++ b/features/step_definitions/stamp_duty.rb
@@ -24,11 +24,21 @@ end
 
 When(/^I enter my house price with "(.*?)"$/) do |amount|
   @stamp_duty.property_price.set amount
+end
+
+When(/^I click next$/) do
   @stamp_duty.next.click
+end
+
+When(/^I select to calculate for a second home$/) do
+  @stamp_duty.second_home.set true
 end
 
 Then(/^I reenter my house price with "(.*?)"$/) do |amount|
   @stamp_duty.property_price_step_two.set amount
+end
+
+When(/^I click next again$/) do
   @stamp_duty.recalculate.click if js_disabled?
 end
 

--- a/features/support/ui/pages/stamp_duty.rb
+++ b/features/support/ui/pages/stamp_duty.rb
@@ -9,6 +9,7 @@ module UI
       element :h2, "h2"
       element :property_price, "form.step_one input[name='stamp_duty[price]']"
       element :property_price_step_two, "form.step_two input[name='stamp_duty[price]']"
+      element :second_home, "form.step_one input[name='stamp_duty[second_home]'][type='checkbox']"
 
       element :next, "form.step_one input[type=submit]"
       element :next_steps, "a[href^='/en/mortgage_calculator/stamp-duty-calculator/next_steps']"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "karma":  ">= 0.10.9",
     "karma-jasmine": "0.1.6",
     "karma-growl-reporter": "~0.1",
-    "phantomjs": ">= 1.9.8",
+    "phantomjs-prebuilt": ">= 1.9.8",
     "karma-phantomjs-launcher": "> 0.0.1"
   }
 }

--- a/spec/javascripts/unit/services/stampDuty.js
+++ b/spec/javascripts/unit/services/stampDuty.js
@@ -1,4 +1,4 @@
-'use strict';
+ 'use strict';
 
 describe('Service: StampDuty', function () {
   beforeEach(module('mortgageCalculatorApp'));
@@ -6,6 +6,9 @@ describe('Service: StampDuty', function () {
   var stampDuty,
       setPrice = function(price) {
         stampDuty.propertyPrice = price;
+      },
+      setSecondHome = function(isSecondHome) {
+        stampDuty.isSecondHome = isSecondHome;
       };
 
   beforeEach(inject(function (StampDuty) {
@@ -17,13 +20,25 @@ describe('Service: StampDuty', function () {
     expect(!!stampDuty).toBe(true);
   });
 
-  describe('Stamp Duty Bands', function() {
+  describe('Stamp Duty Bands - first/only home', function() {
+    beforeEach(function () {
+      setSecondHome(false);
+    });
+
     it('when house price is 0', function() {
       setPrice(0);
 
       expect(stampDuty.cost()).toBe(0);
       expect(stampDuty.percentageTax()).toBe(0);
       expect(stampDuty.totalPurchase()).toBe(0);
+    });
+
+    it('when house price is 40000', function() {
+      setPrice(40000);
+
+      expect(stampDuty.cost()).toBe(0);
+      expect(stampDuty.percentageTax()).toBe(0);
+      expect(stampDuty.totalPurchase()).toBe(40000);
     });
 
     it('when house price is 125000', function() {
@@ -72,6 +87,76 @@ describe('Service: StampDuty', function () {
       expect(stampDuty.cost()).toBe(165750);
       expect(stampDuty.percentageTax()).toBeCloseTo(7.9, 1);
       expect(stampDuty.totalPurchase()).toBe(2265750.00);
+    });
+  });
+
+  describe('Stamp Duty Bands - second home', function() {
+    beforeEach(function () {
+      setSecondHome(true);
+    });
+
+    it('when house price is 0', function() {
+      setPrice(0);
+
+      expect(stampDuty.cost()).toBe(0);
+      expect(stampDuty.percentageTax()).toBe(0);
+      expect(stampDuty.totalPurchase()).toBe(0);
+    });
+
+    it('when house price is 40000', function() {
+      setPrice(40000);
+
+      expect(stampDuty.cost()).toBe(1200);
+      expect(stampDuty.percentageTax()).toBeCloseTo(3, 1);
+      expect(stampDuty.totalPurchase()).toBe(41200);
+    });
+
+    it('when house price is 125000', function() {
+      setPrice(125000);
+
+      expect(stampDuty.cost()).toBe(3750);
+      expect(stampDuty.percentageTax()).toBeCloseTo(3, 1);
+      expect(stampDuty.totalPurchase()).toBe(128750);
+    });
+
+    it('when house price is 185000.00', function() {
+      setPrice(185000);
+
+      expect(stampDuty.cost()).toBe(6750);
+      expect(stampDuty.percentageTax()).toBeCloseTo(3.65, 2);
+      expect(stampDuty.totalPurchase()).toBe(191750.00);
+    });
+
+    it('when house price is 275000', function() {
+      setPrice(275000);
+
+      expect(stampDuty.cost()).toBe(12000);
+      expect(stampDuty.percentageTax()).toBeCloseTo(4.36, 2);
+      expect(stampDuty.totalPurchase()).toBe(287000);
+    });
+
+    it('when house price is 510000.00', function() {
+      setPrice(510000.00);
+
+      expect(stampDuty.cost()).toBe(30800);
+      expect(stampDuty.percentageTax()).toBeCloseTo(6.04, 2);
+      expect(stampDuty.totalPurchase()).toBe(540800.00);
+    });
+
+    it('when house price is 937500', function() {
+      setPrice(937500);
+
+      expect(stampDuty.cost()).toBe(65625);
+      expect(stampDuty.percentageTax()).toBeCloseTo(7.00, 2);
+      expect(stampDuty.totalPurchase()).toBe(1003125.00);
+    });
+
+    it('when house price is 2100000.00', function() {
+      setPrice(2100000.00);
+
+      expect(stampDuty.cost()).toBe(228750);
+      expect(stampDuty.percentageTax()).toBeCloseTo(10.89, 2);
+      expect(stampDuty.totalPurchase()).toBe(2328750.00);
     });
   });
 });

--- a/spec/models/stamp_duty_spec.rb
+++ b/spec/models/stamp_duty_spec.rb
@@ -5,12 +5,38 @@ describe MortgageCalculator::StampDuty do
     it 'sets price to zero' do
       expect(subject.price).to be_zero
     end
+
+    it 'sets second_home to false' do
+      expect(subject.second_home).to be_falsy
+    end
+  end
+
+  describe '#second_home' do
+    subject { described_class.new(second_home: checkbox_value) }
+
+    context 'when "false" is given' do
+      let(:checkbox_value) { "false" }
+
+      it 'is false' do
+        expect(subject.second_home).to be_falsy
+      end
+    end
+
+    context 'when "true" is given' do
+      let(:checkbox_value) { "true" }
+
+      it 'is true' do
+        expect(subject.second_home).to be_truthy
+      end
+    end
   end
 
   it_should_behave_like "currency inputs", [:price]
 
   describe 'calculations' do
-    subject { described_class.new(price: price)}
+    let(:second_home) { 'false' }
+
+    subject { described_class.new(price: price, second_home: second_home)}
 
     context 'when house price is text' do
       let(:price) { "asd" }
@@ -24,57 +50,161 @@ describe MortgageCalculator::StampDuty do
     context 'when house price is 0' do
       let(:price) { 0 }
 
-      its(:tax_due) { is_expected.to be_zero }
-      its(:percentage_tax) { is_expected.to be_zero }
-      its(:total_due) { is_expected.to be_zero }
+      context 'and is not a second home' do
+        let(:second_home) { 'false' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to be_zero }
+      end
+
+      context 'and is a second home' do
+        let(:second_home) { 'true' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to be_zero }
+      end
+    end
+
+    context 'when house price is 40000' do
+      let(:price) { 40000 }
+
+      context 'and is not a second home' do
+        let(:second_home) { 'false' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(40000) }
+      end
+
+      context 'and is a second home' do
+        let(:second_home) { 'true' }
+
+        its(:tax_due) { is_expected.to eq(1200) }
+        its(:percentage_tax) { is_expected.to eq(3) }
+        its(:total_due) { is_expected.to eq(41200) }
+      end
     end
 
     context 'when house price is 125000' do
       let(:price) { 125000 }
 
-      its(:tax_due) { is_expected.to be_zero }
-      its(:percentage_tax) { is_expected.to be_zero }
-      its(:total_due) { is_expected.to eql(125000) }
+      context 'and is not a second home' do
+        let(:second_home) { 'false' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(125000) }
+      end
+
+      context 'and is a second home' do
+        let(:second_home) { 'true' }
+
+        its(:tax_due) { is_expected.to eq(3750) }
+        its(:percentage_tax) { is_expected.to eq(3) }
+        its(:total_due) { is_expected.to eq(128750) }
+      end
     end
 
     context 'when house price is 185000.00' do
       let(:price) { 185000 }
 
-      its(:tax_due) { is_expected.to eql(1200.00) }
-      its(:percentage_tax) { is_expected.to be_within(0.1).of(0.7) }
-      its(:total_due) { is_expected.to eql(186200.00) }
+      context 'and is not a second home' do
+        let(:second_home) { 'false' }
+
+        its(:tax_due) { is_expected.to eql(1200.00) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.7) }
+        its(:total_due) { is_expected.to eql(186200.00) }
+      end
+
+      context 'and is a second home' do
+        let(:second_home) { 'true' }
+
+        its(:tax_due) { is_expected.to eq(6750) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(3.65) }
+        its(:total_due) { is_expected.to eq(191750) }
+      end
     end
 
     context 'when house price is 275000' do
       let(:price) { 275000 }
 
-      its(:tax_due) { is_expected.to eql(3750.00) }
-      its(:percentage_tax) { is_expected.to be_within(0.1).of(1.4) }
-      its(:total_due) { is_expected.to eql(278750) }
+      context 'and is not a second home' do
+        let(:second_home) { 'false' }
+
+        its(:tax_due) { is_expected.to eql(3750.00) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.4) }
+        its(:total_due) { is_expected.to eql(278750) }
+      end
+
+      context 'and is a second home' do
+        let(:second_home) { 'true' }
+
+        its(:tax_due) { is_expected.to eq(12000) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.36) }
+        its(:total_due) { is_expected.to eq(287000) }
+      end
     end
 
     context 'when house price is 510000.00' do
       let(:price) { 510000.00 }
 
-      its(:tax_due) { is_expected.to eql(15500.00) }
-      its(:percentage_tax) { is_expected.to be_within(0.1).of(3) }
-      its(:total_due) { is_expected.to eql(525500.00) }
+      context 'and is not a second home' do
+        let(:second_home) { 'false' }
+
+        its(:tax_due) { is_expected.to eql(15500.00) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(3) }
+        its(:total_due) { is_expected.to eql(525500.00) }
+      end
+
+      context 'and is a second home' do
+        let(:second_home) { 'true' }
+
+        its(:tax_due) { is_expected.to eq(30800) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(6.04) }
+        its(:total_due) { is_expected.to eq(540800) }
+      end
     end
 
     context 'when house price is 937500' do
       let(:price) { 937500 }
 
-      its(:tax_due) { is_expected.to eql(37500) }
-      its(:percentage_tax) { is_expected.to be_within(0.1).of(4) }
-      its(:total_due) { is_expected.to eql(975000) }
+      context 'and is not a second home' do
+        let(:second_home) { 'false' }
+
+        its(:tax_due) { is_expected.to eql(37500) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4) }
+        its(:total_due) { is_expected.to eql(975000) }
+      end
+
+      context 'and is a second home' do
+        let(:second_home) { 'true' }
+
+        its(:tax_due) { is_expected.to eq(65625) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(7.00) }
+        its(:total_due) { is_expected.to eq(1003125) }
+      end
     end
 
     context 'when house price is 2100000.00' do
       let(:price) { 2100000.00 }
 
-      its(:tax_due) { is_expected.to eql(165750) }
-      its(:percentage_tax) { is_expected.to be_within(0.1).of(7.9) }
-      its(:total_due) { is_expected.to eql(2265750.00) }
+      context 'and is not a second home' do
+        let(:second_home) { 'false' }
+
+        its(:tax_due) { is_expected.to eql(165750) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(7.9) }
+        its(:total_due) { is_expected.to eql(2265750.00) }
+      end
+
+      context 'and is a second home' do
+        let(:second_home) { 'true' }
+
+        its(:tax_due) { is_expected.to eq(228750) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(10.89) }
+        its(:total_due) { is_expected.to eq(2328750) }
+      end
     end
   end
 end


### PR DESCRIPTION
**Original PR (for reference):** #247

Currently the Stamp Duty Calculator only calculates for people that only own a single property. Although the copy had been updated to mention the Stamp Duty tax changes that came into force on 1st April this year, there was no way to let the tool know that you were calculating for additional properties.

This PR introduces that feature.

(The feature was added for both JavaScript and non-JavaScript pages, but the gifs for the non-JavaScript version were too large on account of the colossal amount of time it seems to take to page refresh locally 😁)

#### Before

![before](http://g.recordit.co/Bttc1e3hbm.gif)

#### After

![after](http://g.recordit.co/K8s5WJsFVq.gif)