### PR TITLE
7384 - Updating additional home copy

### DIFF
--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -8,7 +8,7 @@ cy:
     pretitle: "Defnyddiwch y gyfrifiannell hon i gyfrifo faint o dreth stamp y bydd angen ichi ei thalu ar gartref newydd"
     h1: "Cyfrifiannell treth stamp"
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl"
-    second_subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy. Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
+    second_subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000 (£40,000 ar gyfer cartrefi ychwanegol). Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy. Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
     subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy."
     subtitle_legislation_change: "O 1 Ebrill 2016 bydd unrhyw un sy'n prynu cartref ychwanegol gan gynnwys eiddo prynu i osod yn gorfod talu ffi ychwanegol o 3% ar ben pob band treth stamp."
     second_subtitle: "Mae Treth Trafodion Tir ac Adeiladau (LBTT) wedi disodli Treth Stamp yn yr Alban. Bydd trethi LBTT yn destun ffi ychwanegol o 3% hefyd ar gyfer ail gartrefi o fis Ebrill 2016 ymlaen."
@@ -22,7 +22,7 @@ cy:
     how_calculated_toggle: "Sut y cyfrifir hyn?"
     how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n prynu eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp gan roi cyfradd dreth effeithiol o 1%."
     how_calculated_additional: "O fis Ebrill 2016, bydd unrhyw un sy'n prynu ail gartref, gan gynnwys eiddo prynu i osod, yn talu 3% ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny'n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750, gan roi cyfradd dreth effeithiol o 4%."
-    how_calculated_extra: "Nid yw eiddo dan £40,000 yn destun SDLT ail gartref"
+    how_calculated_extra: "*Nid yw eiddo dan £40,000 yn destun SDLT ail gartref"
     describe_price_field: Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn.
     activemodel:
       attributes:

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -8,7 +8,7 @@ en:
     pretitle: Use this calculator to work out much Stamp Duty you’ll need to pay on a new home
     h1: Stamp Duty calculator
     title: Calculate the Stamp Duty on your residential property
-    subtitle: "Calculate the Stamp Duty on your residential property in England, Wales or Northern Ireland. You have to pay Stamp Duty (SDLT) if you buy a property costing more than £125,000. Use this calculator to work out how much Stamp Duty is payable."
+    subtitle: "Calculate the Stamp Duty on your residential property in England, Wales or Northern Ireland. You have to pay Stamp Duty (SDLT) if you buy a property costing more than £125,000 (£40,000 for additional homes). Use this calculator to work out how much Stamp Duty is payable."
     subtitle_legislation_change: "From the 1st April 2016 anyone purchasing an additional home including buy to let properties will have to pay an extra 3% surcharge on top of each stamp duty band."
     second_subtitle: "Land and Buildings Transaction Tax (LBTT) has replaced Stamp Duty in Scotland. LBTT rates will also attract a 3% surcharge for second homes from 1st April 2016."
     href_second_subtitle: "Calculate the LBTT payable."
@@ -21,7 +21,7 @@ en:
     how_calculated_toggle: "How is this calculated?"
     how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400 giving an effective tax rate of 1%."
     how_calculated_additional: "As of April 2016, anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
-    how_calculated_extra: "Properties under £40,000 are not subject to second home SDLT"
+    how_calculated_extra: "*Properties under £40,000 are not subject to second home SDLT"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:
       attributes:


### PR DESCRIPTION
Adds the extra copy '£40,000 for additional homes' to the first page of the Stamp Duty Calculator.
Adds an asterisk to indicate a footnote on the second page.

![image](https://cloud.githubusercontent.com/assets/14920201/15740349/79093dba-28ac-11e6-8325-20692c3cb984.png)

