### PR TITLE
7384 - Updating gem version

### DIFF
--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 1
-    MINOR = 3
+    MINOR = 4
     PATCH = 9
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
In User Story 7384 we are changing some copy in the Stamp Duty Calculator, but the PR didn't include a version bump. This corrects that.