### PR TITLE
[DEV APPROVED] 7405 - New tooltip and accessibility fixes for colour changing

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/directives/tooltip.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/directives/tooltip.js
@@ -8,6 +8,7 @@ App.directive('ngTooltip', function() {
         var tooltipID = $element.attr('id'),
             $inputTarget = $('[aria-describedby="' + tooltipID + '"]'),
             hiddenClass = 'tooltip--hidden',
+            persistOnScreen = $element.attr('data-tooltip-persist'),
             debounceTimer;
 
         $element.addClass(hiddenClass);
@@ -25,6 +26,11 @@ App.directive('ngTooltip', function() {
         $element.on('focusout', handleBlur);
 
         function handleBlur(e) {
+          if (persistOnScreen) {
+            // If we do not want the tooltip to hide onBlur
+            return true;
+          }
+
           clearTimeout(debounceTimer);
           debounceTimer = setTimeout(function() {
             var $activeElement = $(document.activeElement),

--- a/app/assets/stylesheets/mortgage_calculator/components/_affordability.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_affordability.scss
@@ -78,11 +78,19 @@
       }
     }
   }
+}
 
-  .affcalc__row--term-years-tooltip {
-    margin-top: 4em;
+.affcalc__anchor-header-offset {
+  &:before {
+    content: ''; 
+    display: block; 
+    position: relative; 
+    width: 0;
+    height: 200px; 
+    margin-top: -200px; 
     @include respond-to($mq-m) {
-      margin-top: 0;
+      height: 165px; 
+      margin-top: -165px;
     }
   }
 }

--- a/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
@@ -180,10 +180,6 @@
     width: auto;
     width: min-content;
   }
-
-  .label-follower {
-    color: $color-green-secondary;
-  }
 }
 
 .form__input-container--pulled {

--- a/app/assets/stylesheets/mortgage_calculator/components/_risk.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_risk.scss
@@ -35,104 +35,44 @@
   display: none;
 }
 
-.risk--high {
-  .risk__accent--color-only,
-  .risk__accent {
-    color: $colour-risk-high;
+$risk-levels: (high, $colour-risk-high) (medium, $colour-risk-medium) (low, $colour-risk-low);
 
-    .ui-slider-handle {
+@each $level in $risk-levels {
+
+  $level-name: nth($level, 1);
+  $level-color: nth($level, 2);
+
+  .risk--#{$level-name} {
+    .risk__accent--color-only {
+      background-color: $level-color;
+    }
+
+    .ui-slider .ui-slider-handle {
       &:focus,
       &:active {
-        border-color: $colour-risk-high;
+        border-color: $level-color;
       }
     }
 
-    .ui-slider-handle {
+    .ui-slider .ui-slider-handle {
       &:after {
-        border-bottom-color: $colour-risk-high;
+        border-bottom-color: $level-color;
       }
     }
-  }
 
-  .risk-slice--incoming {
-    fill: $colour-risk-high;
-  }
-
-  .risk-key--incoming {
-    &:after {
-      background: $colour-risk-high;
+    .risk-slice--incoming {
+      fill: $level-color;
     }
-  }
 
-  .risk--show-on-high {
-    display: block;
+    .risk-key--incoming {
+      &:after {
+        background: $level-color;
+      }
+    }
+
+    .risk--show-on-#{$level-name} {
+      display: block;
+    }
   }
 }
 
-.risk--medium {
-  .risk__accent--color-only,
-  .risk__accent {
-    color: $colour-risk-medium;
-
-    .ui-slider-handle {
-      &:focus,
-      &:active {
-        border-color: $colour-risk-medium;
-      }
-    }
-
-    .ui-slider-handle {
-      &:after {
-        border-bottom-color: $colour-risk-medium;
-      }
-    }
-  }
-
-  .risk-slice--incoming {
-    fill: $colour-risk-medium;
-  }
-
-  .risk-key--incoming {
-    &:after {
-      background: $colour-risk-medium;
-    }
-  }
-
-  .risk--show-on-medium {
-    display: block;
-  }
-}
-
-.risk--low {
-  .risk__accent--color-only,
-  .risk__accent {
-    color: $colour-risk-low;
-
-    .ui-slider-handle {
-      &:focus,
-      &:active {
-        border-color: $colour-risk-low;
-      }
-    }
-
-    .ui-slider-handle {
-      &:after {
-        border-bottom-color: $colour-risk-low;
-      }
-    }
-  }
-
-  .risk-slice--incoming {
-    fill: $colour-risk-low;
-  }
-
-  .risk-key--incoming {
-    &:after {
-      background: $colour-risk-low;
-    }
-  }
-
-  .risk--show-on-low {
-    display: block;
-  }
-}

--- a/app/assets/stylesheets/mortgage_calculator/components/_tooltip.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_tooltip.scss
@@ -11,6 +11,13 @@
   }
 }
 
+.tooltip--boxout {
+  @extend %clearfix;
+  margin-top: $baseline-unit*4;
+  border: 1px solid $color-grey-medium-dark;
+  padding: $baseline-unit;
+}
+
 .tooltip--push {
   @include respond-to($mq-m) {
     margin-top: $baseline-unit*8;
@@ -19,6 +26,15 @@
 
 .tooltip--push-small {
   @include respond-to($mq-m) {
-    margin-top: $baseline-unit*4;
+    margin-top: $baseline-unit*2;
   }
+}
+
+.tooltip__title {
+  margin-top: $baseline-unit;
+  color: $color-link-list-text;
+}
+
+.tooltip__link {
+  float: right;
 }

--- a/app/assets/stylesheets/mortgage_calculator/lib/_variables.scss
+++ b/app/assets/stylesheets/mortgage_calculator/lib/_variables.scss
@@ -11,8 +11,8 @@ $color-error: #ff0000;
 
 $mortgagecalc_mq-s: px(570);
 
-$colour-risk-low: #77bf24;
-$colour-risk-medium: #f08d00;
-$colour-risk-high: #e80000;
+$colour-risk-low: lighten($color-green-one, 10) ;
+$colour-risk-medium: lighten($color-yellow-light, 10);
+$colour-risk-high: lighten($color-red-medium, 20);
 
 $colour-label-accent: #f7eea6;

--- a/app/views/mortgage_calculator/affordabilities/_field_tooltip.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_field_tooltip.html.erb
@@ -1,6 +1,6 @@
 <div class="tooltip tooltip--onfocus" ng-tooltip ng-cloak role="tooltip"
   <%== html.map { |k, v| %Q{#{k}="#{v}"} }.join(' ') %>>
   <div class="tooltip__content-container">
-    <p class="tooltip__text risk__accent--color-only"><%= text %></p>
+    <p class="tooltip__text"><%= text %></p>
   </div>
 </div>

--- a/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
@@ -28,13 +28,24 @@
   <div class="affcalc__row affcalc__row--slider">
     <div class="affcalc__col--clip">
       <%= render 'mortgage_calculator/affordabilities/form/term_years', f: f %>
-      <div class="affcalc__row--term-years-tooltip">
-        <%= field_tooltip text: t("affordability.tooltips.mortgage_calculator/results.term_years"),
-          html: {
-            id: 'term_years_tip'
-          }
-        %>
-      </div>
+      
+        <div class="tooltip tooltip--onfocus tooltip--boxout tooltip--push-top" ng-tooltip ng-cloak data-tooltip-persist="true" role="tooltip" id="term_years_tip">
+          <div class="tooltip__content-container">
+            <h4 class="tooltip__title"><%= t("affordability.tooltips.mortgage_calculator/results.title") %></h4>
+            <p class="tooltip__text"><%= t("affordability.tooltips.mortgage_calculator/results.term_years") %></p>
+            <a class="tooltip__link" href="#affcalc-summary">
+              <span class="risk--show-on-low">
+                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_low") %>
+              </span>
+              <span class="risk--show-on-medium">
+                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_medium") %>
+              </span>
+              <span class="risk--show-on-high">
+                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_high") %>
+              </span>
+            </a>
+          </div>
+        </div>
     </div>
   </div>
 
@@ -58,7 +69,7 @@
 
   <div class="affcalc__row">
     <div class="affcalc__col--clip" ng-cloak>
-      <h3><%= t "affordability.titles.how_affect_budget" %></h3>
+      <h3 class="affcalc__anchor-header-offset" id="affcalc-summary"><%= t "affordability.titles.how_affect_budget" %></h3>
 
       <% if @affordability.only_rent_and_mortgage_warning? %>
         <%= inset_block(t("affordability.warnings.only_rent_and_mortgage_html",

--- a/app/views/mortgage_calculator/affordabilities/form/_annual_interest_rate.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/form/_annual_interest_rate.html.erb
@@ -26,7 +26,7 @@
   "value" => @affordability.interest_rate
 %>
 
-<div class="slider slider--with-follower-top slider--squeeze risk__accent--color-only"
+<div class="slider slider--with-follower-top slider--squeeze"
      ui-slider
      min="repayments.minInterestRate"
      max="repayments.maxInterestRate"

--- a/app/views/mortgage_calculator/affordabilities/form/_borrowing.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/form/_borrowing.html.erb
@@ -14,7 +14,7 @@
   "value" => @affordability.borrowing_formatted
 %>
 
-<div class="slider slider--with-follower-top slider--squeeze risk__accent--color-only"
+<div class="slider slider--with-follower-top slider--squeeze"
      ui-slider min="affordability.minimumBorrowing()"
      max="affordability.maximumBorrowing()"
      step="10"

--- a/app/views/mortgage_calculator/affordabilities/form/_term_years.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/form/_term_years.html.erb
@@ -27,7 +27,7 @@
   "value" => @affordability.term_years
 %>
 
-<div class="slider slider--with-follower-top slider--squeeze risk__accent--color-only"
+<div class="slider slider--with-follower-top slider--squeeze"
      ui-slider
      min="5"
      max="40"

--- a/config/locales/affordability.cy.yml
+++ b/config/locales/affordability.cy.yml
@@ -99,6 +99,10 @@ cy:
         monthly_net_income_1: "Incwm misol yr ail ymgeisydd wedi treth, llai pensiwn, Yswiriant Gwladol, a didyniadau eraill"
       mortgage_calculator/results:
         term_years: "Gall newid cyfnod y morgais effeithio ar y swm o arian y cewch ei fenthyca yn ogystal â chost eich ad-daliadau misol. Er enghraifft, bydd cyfnod byrrach yn debygol o olygu taliadau misol uwch, tra bydd cyfnod hirach yn golygu taliadau is, wedi eu rhannu dros gyfnod hirach o amser."
+        title: "Darllenwch"
+        link_text_low: "Gweler y crynodeb"
+        link_text_medium: "Rydych mewn perygl o wario mwy na’ch cyllideb"
+        link_text_high: "Rydych mewn perygl mawr iawn o wario mwy na’ch cyllideb"
     titles:
       annual_income: "Incwm Blynyddol"
       take_home: "Cyflog clir misol"

--- a/config/locales/affordability.en.yml
+++ b/config/locales/affordability.en.yml
@@ -99,6 +99,10 @@ en:
         monthly_net_income_1: "Second applicant’s income after tax, minus pension, NI, and other deductions"
       mortgage_calculator/results:
         term_years: "Changing the term of the mortgage can affect the total amount of money you are able to borrow as well as the cost of your monthly repayments. For example, a shorter term will probably result in higher monthly payments, whereas a longer term means lower payments, spread out over a longer period of time."
+        title: "Please read"
+        link_text_low: "See summary"
+        link_text_medium: "You are at risk of overstretching your budget"
+        link_text_high: "You run a very high risk of stretching your budget"
     titles:
       annual_income: "Annual Income"
       take_home: "Monthly take-home pay"


### PR DESCRIPTION
## Overview
This PR adds the coloured labels and tooltip with a border:

![image](https://cloud.githubusercontent.com/assets/14920201/16041184/f4d2f8ae-322b-11e6-8174-938eafdae3c3.png)

## Details
1. Changes the colours of the labels so that they are black text on a colour-changing background. This fixes a problem that we had before where the colour contrast was too low.
2. Adds a tooltip that 'persists on screen' once revealed. All of the other tooltips disappear on the 'blur' event, which is not what we want for this one as it has important content and a link within it.
3. Refactors some of the CSS for the colour-changing, and adds a class for in-page anchor links that is offset from the top (to avoid the sticky header appearing over the content).

## Notes
I thought about putting the HTML for the new tooltip into a partial in the same way as the existing tooltips work - see `app/views/mortgage_calculator/affordabilities/_field_tooltip.erb` - but didn't for two reasons, this is a specific one-off use case for this markup, and I had to pass a lot of parameters to the partial to get the data into it. Happy to refactor this if there's a better solution though.