### PR TITLE
7405 - Using ng-cloak for better rendering

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_affordability.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_affordability.scss
@@ -55,7 +55,9 @@
     @include respond-to($mq-m) {
       @include column(6);
       @include push(1);
-      position: absolute;
+      .js & {
+        position: absolute;
+      }
     }
     @include respond-to($mq-l) {
       @include column(7);

--- a/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
@@ -25,7 +25,7 @@
     </div>
   </div>
 
-  <div class="affcalc__row affcalc__row--slider">
+  <div class="affcalc__row affcalc__row--slider" ng-cloak>
     <div class="affcalc__col--clip">
       <%= render 'mortgage_calculator/affordabilities/form/term_years', f: f %>
       
@@ -49,7 +49,7 @@
     </div>
   </div>
 
-  <div class="affcalc__row affcalc__row--slider">
+  <div class="affcalc__row affcalc__row--slider" ng-cloak>
     <div class="affcalc__col--clip">
       <%= render 'mortgage_calculator/affordabilities/form/annual_interest_rate', f: f %>
     </div>


### PR DESCRIPTION
When the third step of the Mortgage Affordability Calculator loads, there is a flash of pre-formatted AngularJS template code which looks untidy.

This PR uses the `ng-cloak` directive to hide this content until AngularJS kicks in.

This is what the flash of Angular code looks like:

![image](https://cloud.githubusercontent.com/assets/14920201/16080242/c644e5c2-32ff-11e6-88fd-563ef36b9f3c.png)
