### PR TITLE
7405 Adding triangle and bold text to tooltip

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_tooltip.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_tooltip.scss
@@ -37,4 +37,24 @@
 
 .tooltip__link {
   float: right;
+  padding-right: $baseline-unit * 7;
+  position: relative;
+  &:after {
+    content: '';
+    display: block;
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 15px 15px 0 15px;
+    border-color: $color-green-dark transparent transparent transparent;
+  }
+
+  .no-js & {
+    .risk--show-on-low {
+      display: block;
+    }
+  }
 }

--- a/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
@@ -35,13 +35,13 @@
             <p class="tooltip__text"><%= t("affordability.tooltips.mortgage_calculator/results.term_years") %></p>
             <a class="tooltip__link" href="#affcalc-summary">
               <span class="risk--show-on-low">
-                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_low") %>
+                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_low_html") %>
               </span>
               <span class="risk--show-on-medium">
-                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_medium") %>
+                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_medium_html") %>
               </span>
               <span class="risk--show-on-high">
-                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_high") %>
+                <%= t("affordability.tooltips.mortgage_calculator/results.link_text_high_html") %>
               </span>
             </a>
           </div>

--- a/app/views/mortgage_calculator/affordabilities/step_3.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/step_3.html.erb
@@ -28,7 +28,7 @@
 <!--<![endif]-->
 <% end %>
 
-<div ng-controller="CalculatorCtrl" class="affcalc risk--<%= @affordability.risk_level %>"
+<div ng-controller="CalculatorCtrl" class="affcalc"
    ng-class="{'high':'risk--high', 'medium':'risk--medium', 'low':'risk--low'}[affordability.riskLevel()]">
    <div class="buffer--<%= @affordability.remaining_vector %>" ng-class="{'positive':'buffer--positive', 'negative':'buffer--negative'}[affordability.remainingVector()]">
     <%= render 'form_step3' %>

--- a/config/locales/affordability.cy.yml
+++ b/config/locales/affordability.cy.yml
@@ -100,9 +100,9 @@ cy:
       mortgage_calculator/results:
         term_years: "Gall newid cyfnod y morgais effeithio ar y swm o arian y cewch ei fenthyca yn ogystal â chost eich ad-daliadau misol. Er enghraifft, bydd cyfnod byrrach yn debygol o olygu taliadau misol uwch, tra bydd cyfnod hirach yn golygu taliadau is, wedi eu rhannu dros gyfnod hirach o amser."
         title: "Darllenwch"
-        link_text_low: "Gweler y crynodeb"
-        link_text_medium: "Rydych mewn perygl o wario mwy na’ch cyllideb"
-        link_text_high: "Rydych mewn perygl mawr iawn o wario mwy na’ch cyllideb"
+        link_text_low_html: "Gweler y crynodeb"
+        link_text_medium_html: "Rydych mewn perygl o wario mwy na’ch cyllideb"
+        link_text_high_html: "Rydych mewn perygl mawr iawn o wario mwy na’ch cyllideb"
     titles:
       annual_income: "Incwm Blynyddol"
       take_home: "Cyflog clir misol"

--- a/config/locales/affordability.en.yml
+++ b/config/locales/affordability.en.yml
@@ -100,9 +100,9 @@ en:
       mortgage_calculator/results:
         term_years: "Changing the term of the mortgage can affect the total amount of money you are able to borrow as well as the cost of your monthly repayments. For example, a shorter term will probably result in higher monthly payments, whereas a longer term means lower payments, spread out over a longer period of time."
         title: "Please read"
-        link_text_low: "See summary"
-        link_text_medium: "You are at risk of overstretching your budget"
-        link_text_high: "You run a very high risk of stretching your budget"
+        link_text_low_html: "See summary"
+        link_text_medium_html: "You are at <b>risk</b> of overstretching your budget"
+        link_text_high_html: "You run a <b>very high risk</b> of stretching your budget"
     titles:
       annual_income: "Annual Income"
       take_home: "Monthly take-home pay"


### PR DESCRIPTION
Adds the green triangle and bold text to the link within the tooltip. Note: there is no bold text required in the Welsh version.

![image](https://cloud.githubusercontent.com/assets/14920201/16117853/1a67271a-33cc-11e6-8606-1704fa8a4a13.png)

This also fixes a bug within `app/views/mortgage_calculator/affordabilities/step_3.html.erb` where the class was being added on the server side as well as using `ng-class`, which was resulting in duplicate classes on this element.
