### PR TITLE
Lock karma down to v0.13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mortgage-calculator",
   "dependencies": {
-    "karma": ">= 0.10.9",
+    "karma": "~0.13.0",
     "karma-jasmine": "0.1.6",
     "karma-growl-reporter": "~0.1",
     "phantomjs-prebuilt": ">= 1.9.8",


### PR DESCRIPTION
Couldn't find any clear info as to what might need changing for these to run successfully under Karma 1.x so for now locking it at 0.13.x.

Will consult @slaywell when he's back for his opinion.