### PR TITLE
7350 - Dynamic sliders bug fix, correct amounts now set

### DIFF
--- a/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step3.html.erb
@@ -120,7 +120,7 @@
           <span class="form__input-label" id="label_lifestyle_a">&pound;</span>
             <%= f.text_field :lifestyle_costs,
                              :value => @affordability.lifestyle_costs_formatted,
-                             class: 'dynamic-slider-property form__input',
+                             class: 'dynamic-slider-property-two form__input',
                              "currency" => '',
                              "placeholder" => "0",
                              "data-m-dec" => "0",
@@ -138,7 +138,7 @@
         <div class="slider"
              id="slider-lifestyle"
              ui-slider
-             dynamic-for='dynamic-slider-property'
+             dynamic-for='dynamic-slider-property-two'
              percentage-for-minimum="20"
              percentage-for-maximum="200"
              custom-slider-max="250"


### PR DESCRIPTION
## Bug: 
We have a live bug with the 'Living Expenses' slider on the Mortgage Affordability Calculator. When you interact with the 'top' slider this reconfigures the 'Living Expenses' slider with unrealistically large amounts.

![image](https://cloud.githubusercontent.com/assets/14920201/16913097/31f700d0-4ce0-11e6-9ce7-67dcd1ff9a3f.png)

This is because the 'Living Expenses' slider has the same classname (`dynamic-slider-property`) with the top slider, which is creating an unwanted binding.

## Fix
This PR gives the 'Living Expenses' a different classname which removes the binding between the 'Living Expenses' amount and the top slider.

The 'Living Expenses' slider is now within a range of 0-500 (if the user has not entered a value) or 20%-200% of the user entered value.