### PR TITLE
[DEV APPROVED]Redesign first page of stamp duty calculator

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -1,0 +1,134 @@
+.stamp-duty__step-one {
+  margin-top: 0;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    margin-top: $baseline-unit*5;
+  }
+}
+
+.stamp-duty {
+  border: solid $color-grey-light 1px;
+  overflow: hidden;
+  padding: 0 $baseline-unit*4;
+  max-width: none;
+  margin-top: $baseline-unit;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    margin-top: $baseline-unit*8;
+  }
+}
+
+.stamp-duty__heading {
+  @include body(24,36);
+  margin-top: $baseline-unit*4;
+  margin-bottom: $baseline-unit;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    @include body(40,45);
+  }
+}
+
+.stamp-duty__subheading {
+  @include body(16,24);
+  font-weight: 300;
+  margin-bottom: 0;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    @include body(21,24);
+  }
+}
+
+.stamp-duty__form {
+  margin-top: 0;
+  overflow: hidden;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    margin: 0 0 $baseline-unit*3;
+  }
+}
+
+.stamp-duty__input-description {
+  display: block;
+  @include body(14,24);
+  color: $color-true-black;
+  font-weight: 600;
+  padding: $baseline-unit*2 0;
+  margin: 0;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    float: left;
+    display: inline-block;
+    @include body(21,24);
+  }
+}
+
+input.stamp-duty__input {
+  @include body(21,24);
+  border: 1px solid $color-grey-light;
+  border-radius: 0.2rem;
+  display: inline-block;
+  height: 3.2rem;
+  padding-left: 2rem;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    @include body(24,24);
+    float: left;
+  }
+}
+
+.stamp-duty__input--unit {
+  @include body(21,24);
+  font-weight: 400;
+  color: $color-true-black;
+  position: absolute;
+  top: 0.9rem;
+  left: 1rem;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    @include body(24,24);
+  }
+}
+
+.stamp-duty__input--wrapper {
+  width: 100%;
+  position: relative;
+  float: left;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    margin-left: $baseline-unit*2;
+    width: 40%;
+  }
+}
+
+.stamp-duty__submit {
+  width: 100%;
+  margin-top: $baseline-unit;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    width: $baseline-unit*14;
+    margin: 0 $baseline-unit*2;
+  }
+}
+
+.stamp-duty__additional-property-check {
+  overflow: hidden;
+  @include body(13,24);
+  margin: $baseline-unit*3 0;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    @include body(18,24);
+  }
+}
+
+.stamp-duty__description {
+  overflow: hidden;
+  margin-bottom: $baseline-unit*6;
+}
+
+.stamp-duty__description-item {
+  @include column(12);
+
+  @include respond-to($mortgagecalc_mq-s) {
+    @include column(6);
+  }
+}

--- a/app/assets/stylesheets/mortgage_calculator/lib/_variables.scss
+++ b/app/assets/stylesheets/mortgage_calculator/lib/_variables.scss
@@ -10,6 +10,7 @@ $affordability-width: 960px;
 $color-error: #ff0000;
 
 $mortgagecalc_mq-s: px(570);
+$mortgagecalc_mq-m: px(720);
 
 $colour-risk-low: lighten($color-green-one, 10) ;
 $colour-risk-medium: lighten($color-yellow-light, 10);

--- a/app/views/layouts/mortgage_calculator/application.html.erb
+++ b/app/views/layouts/mortgage_calculator/application.html.erb
@@ -39,10 +39,8 @@
 <% end %>
 
 <% content_for(:engine_content) do %>
-  <div>
-    <div ng-app="mortgageCalculatorApp" class="mortgagecalc">
-      <%= yield %>
-    </div>
+  <div ng-app="mortgageCalculatorApp" class="mortgagecalc">
+    <%= yield %>
   </div>
 <% end %>
 

--- a/app/views/mortgage_calculator/stamp_duties/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step1.html.erb
@@ -1,53 +1,51 @@
-<div class="mortgagecalc__panel mortgagecalc__panel--full">
-  <div class="intro"><%= I18n.t('stamp_duty.title') %></div>
-  <p class="mortgagecalc__intro"><%= I18n.t('stamp_duty.subtitle') %></p>
-  <p class="mortgagecalc__intro"><%= I18n.t('stamp_duty.subtitle_legislation_change') %></p>
-  <p class="mortgagecalc__intro">
-     <%= I18n.t('stamp_duty.second_subtitle') %>
-     <%= link_to t('stamp_duty.href_second_subtitle'), t('stamp_duty.url_second_subtitle') %>
-  </p>
-</div>
+<h2 class="intro stamp-duty__subheading"><%= I18n.t('stamp_duty.title') %></h2>
 
-<%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_one', novalidate: '' } do |f| %>
-  <div class="mortgagecalc__panel">
-    <div class="form__item">
-      <%= f.label :price %>
-      <div class="visually-hidden" id="mc_accessibility_describe_price"><%= t 'stamp_duty.describe_price_field' %></div>
+<%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_one stamp-duty__step-one', novalidate: '' } do |f| %>
+  <div class="stamp-duty__form form__item">
+    <%= f.label :price, class: "stamp-duty__input-description" %>
+    <div class="visually-hidden" id="mc_accessibility_describe_price"><%= t 'stamp_duty.describe_price_field' %></div>
 
-      <span class="form__input-container form__input-container--pulled">
-        <span class="form__input-label">£</span>
-        <%= f.text_field :price,
-                         :value => @stamp_duty.price_formatted,
-                         class: 'form__input dynamic-slider-property',
-                         "autofocus" => '',
-                         "ng-model" => "stampDuty.propertyPrice",
-                         "placeholder" => "0.00",
-                         "currency" => '',
-                         "data-m-dec" =>"0",
-                         "pattern" => '\d*' %>
-        <span class="form__input-outline"></span>
-      </span>
+    <span class="stamp-duty__input--wrapper">
+      <span class="stamp-duty__input--unit">£</span>
+      <%= f.text_field :price,
+                       :value => @stamp_duty.price_formatted,
+                       "autofocus" => '',
+                       "ng-model" => "stampDuty.propertyPrice",
+                       "placeholder" => "0.00",
+                       "currency" => '',
+                       "data-m-dec" =>"0",
+                       "pattern" => '\d*',
+                       "class" => 'stamp-duty__input' %>
+    </span>
 
-    </div>
-    <div class="form__item">
-      <label class="label--accent">
-        <%= f.check_box :second_home, {'ng-model' => 'stampDuty.isSecondHome'}, 'true', 'false' %>
-        <%= I18n.t('stamp_duty.second_home.label') %>
-      </label>
-    </div>
+      <%= f.submit I18n.t("stamp_duty.next"),
+      class: "button button--primary stamp-duty__submit",
+        'ng-click' => 'navigateAndFocus($event)',
+        'ng-disabled' => '!stampDuty.propertyPrice',
+        'analytics-category' => 'Stamp Duty Calculator',
+        'analytics-action' => 'Completion',
+        'analytics-label' => 'Click',
+        'analytics' => '',
+        'analytics-on' => 'click'
+        %>
   </div>
 
-  <div class="mortgagecalc__panel mortgagecalc__panel--full mortgagecalc__panel--with-form mortgagecalc__panel--space">
-    <%= f.submit I18n.t("stamp_duty.next"),
-                 class: "button button--primary mortgagecalc__submit",
-                 'ng-click' => 'navigateAndFocus($event)',
-                 'ng-disabled' => '!stampDuty.propertyPrice',
-                 'analytics-category' => 'Stamp Duty Calculator',
-                 'analytics-action' => 'Completion',
-                 'analytics-label' => 'Click',
-                 'analytics' => '',
-                 'analytics-on' => 'click'
-                 %>
+  <label class="stamp-duty__additional-property-check">
+    <%= f.check_box :second_home, {'ng-model' => 'stampDuty.isSecondHome'}, 'true', 'false' %>
+    <%= I18n.t('stamp_duty.second_home.label') %>
+  </label>
 
-  </div>
 <% end %>
+<hr />
+<div class="stamp-duty__description">
+  <div class="stamp-duty__description-item">
+    <p><%= I18n.t('stamp_duty.subtitle') %></p>
+  </div>
+  <div class="stamp-duty__description-item">
+    <p><%= I18n.t('stamp_duty.subtitle_legislation_change') %></p>
+    <p>
+      <%= I18n.t('stamp_duty.second_subtitle') %>
+      <%= link_to t('stamp_duty.href_second_subtitle'), t('stamp_duty.url_second_subtitle') %>
+    </p>
+  </div>
+</div>

--- a/app/views/mortgage_calculator/stamp_duties/_header.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_header.html.erb
@@ -1,3 +1,1 @@
-<div class="mortgagecalc__panel mortgagecalc__panel--full">
-  <h1><%= I18n.t('stamp_duty.h1') %></h1>
-</div>
+<h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.h1') %></h1>

--- a/app/views/mortgage_calculator/stamp_duties/show.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/show.html.erb
@@ -1,4 +1,4 @@
-<div ng-controller="CalculatorCtrl" class="mortgagecalc__container">
+<div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
   <%= render 'header' %>
 
   <% @stamp_duty.errors.full_messages.each do |m| %>

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -26,7 +26,7 @@ en:
     activemodel:
       attributes:
         mortgage_calculator/stamp_duty:
-          price: The price of the property is
+          price: "Property Price:"
     caveat:
       title: Important
       one: "This calculator is a guide only to Stamp Duty on residential properties. Different rates apply to properties for non-residential use."


### PR DESCRIPTION
This PR includes the first part of a redesign of the Stamp Duty Calculator focussing on the first page.

**Original Desktop Layout:**
![screen shot 2016-11-21 at 11 05 28](https://cloud.githubusercontent.com/assets/67151/20480853/3bc81982-afdc-11e6-825a-2921c4dc0dbd.png)

**New Desktop Layout:**
![screen shot 2016-11-24 at 11 14 59](https://cloud.githubusercontent.com/assets/11137272/20596614/522cb676-b237-11e6-9695-34688740dee6.png)


**Original Mobile Layout:**
<img width="204" alt="screen shot 2016-11-21 at 11 05 15" src="https://cloud.githubusercontent.com/assets/67151/20480889/582e8ade-afdc-11e6-953b-84e995e451a1.png">


**New** Mobile Layout:
![screen shot 2016-11-24 at 11 14 49](https://cloud.githubusercontent.com/assets/11137272/20596612/4f7796ee-b237-11e6-9223-fcea83426b21.png)


