### PR TITLE
[DEV APPROVED] Stamp Duty Calculator: Style Desktop JS Version

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -89,11 +89,13 @@ input.stamp-duty__input {
   }
 }
 
-.stamp-duty__input--wrapper {
+.stamp-duty__input-wrapper {
   width: 100%;
   position: relative;
   float: left;
+}
 
+.stamp-duty__input-wrapper--inline {
   @include respond-to($mortgagecalc_mq-s) {
     margin-left: $baseline-unit*2;
     width: 40%;

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -176,3 +176,7 @@ input.stamp-duty__input {
 .stamp-duty__results-tax-rate {
   margin: $baseline-unit 0;
 }
+
+.stamp-duty__button {
+  width: 100%;
+}

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -180,3 +180,17 @@ input.stamp-duty__input {
 .stamp-duty__button {
   width: 100%;
 }
+
+.stamp-duty__info-subheading {
+  @include body(24,24);
+  font-weight: 700;
+  color: $color-green-secondary;
+}
+
+p.stamp-duty__info-tip {
+  @include body(16,24)
+}
+
+.stamp-duty__info-tip-link {
+  @include body(16,24)
+}

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -159,3 +159,20 @@ input.stamp-duty__input {
   padding-left: $baseline-unit*4;
   margin-top: $baseline-unit*2;
 }
+
+.stamp-duty__results {
+  background: $color-grey-pale;
+  padding: $baseline-unit*3;
+}
+
+.stamp-duty__results-heading {
+  color: $color-true-black;
+  font-weight: 500;
+  display: inline;
+
+  @include body(24,36);
+}
+
+.stamp-duty__results-tax-rate {
+  margin: $baseline-unit 0;
+}

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -136,3 +136,24 @@ input.stamp-duty__input {
 .stamp-duty__have-you-tried {
   @include body(20, 24);
 }
+
+.stamp-duty__calculator-column {
+  display: inline;
+  float: left;
+  width: 50%;
+
+  margin-top: $baseline-unit*2;
+
+  border-right: 1px solid $color-grey-pale;
+  padding-right: $baseline-unit*4;
+  margin-bottom: $baseline-unit*4;
+}
+
+.stamp-duty__info-column {
+  display: inline;
+  float: left;
+  width: 50%;
+
+  padding-left: $baseline-unit*4;
+  margin-top: $baseline-unit*2;
+}

--- a/app/views/mortgage_calculator/stamp_duties/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step1.html.erb
@@ -5,7 +5,7 @@
     <%= f.label :price, class: "stamp-duty__input-description" %>
     <div class="visually-hidden" id="mc_accessibility_describe_price"><%= t 'stamp_duty.describe_price_field' %></div>
 
-    <span class="stamp-duty__input--wrapper">
+    <span class="stamp-duty__input-wrapper stamp-duty__input-wrapper--inline">
       <span class="stamp-duty__input--unit">£</span>
       <%= f.text_field :price,
                        :value => @stamp_duty.price_formatted,

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -1,8 +1,8 @@
 <h2 class="intro stamp-duty__subheading"><%= I18n.t('stamp_duty.title') %></h2>
 <div class="stamp-duty__calculator-column">
-  <%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_two mortgagecalc__form mortgagecalc__form--pull', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
-    <div class="form__item">
-      <%= f.label :price %>
+  <%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
+    <div class="form__item stamp-duty__form">
+      <%= f.label :price, class: 'stamp-duty__input-description' %>
       <div class="visually-hidden"
             id="mc_accessibility_describe_price">
         <%= t 'stamp_duty.describe_price_field' %>

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -8,11 +8,11 @@
         <%= t 'stamp_duty.describe_price_field' %>
       </div>
 
-      <span class="form__input-container">
-        <span class="form__input-label">£</span>
+      <span class="stamp-duty__input-wrapper">
+        <span class="stamp-duty__input--unit">£</span>
         <%= f.text_field :price,
                          :value => @stamp_duty.price_formatted,
-                         class: 'form__input dynamic-slider-property',
+                         class: 'stamp-duty__input dynamic-slider-property',
                          "ng-model" => "stampDuty.propertyPrice",
                          "placeholder" => "0.00",
                          "currency" => '',
@@ -26,8 +26,8 @@
                          "aria-describedby" => 'mc_accessibility_describe_price',
                          "autoselect" => ""
                          %>
-        <span class="form__input-outline"></span>
       </span>
+
     </div>
     <%= f.hidden_field :second_home %>
 

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -55,13 +55,13 @@
     <h4 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h4>
     <p><%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_calculator'),
                    full_mortgage_calculator_url,
-                   class: "button button--primary mortgagecalc__spread",
+                   class: "button button--primary mortgagecalc__spread stamp-duty__button",
                    target: "_blank",
                    rel: no_follow? %>
 
       <%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_affordability_calculator'),
                    full_mortgage_affordability_calculator_url,
-                   class: "button button--primary mortgagecalc__spread",
+                   class: "button button--primary mortgagecalc__spread stamp-duty__button",
                    target: "_blank",
                    rel: no_follow? %></p>
   </div>

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -69,16 +69,14 @@
 
 <div class="stamp-duty__info-column">
   <div class="callout">
-    <h3 class="mortgagecalc__subheading"><%= I18n.t("stamp_duty.next_steps.learn_more.title") %></h3>
-    <p><%= I18n.t("stamp_duty.next_steps.learn_more.tip_1") %></p>
+    <div class="stamp-duty__info-subheading"><%= I18n.t("stamp_duty.next_steps.learn_more.title") %></div>
+    <p class="stamp-duty__info-tip"><%= I18n.t("stamp_duty.next_steps.learn_more.tip_1") %></p>
   </div>
-</div>
 
-<div class="mortgagecalc__panel mortgagecalc__panel--nudge">
   <h3 class="mortgagecalc__subheading"><%= I18n.t("stamp_duty.next_steps.find_out_more.title") %>:</h3>
   <ul>
     <% I18n.t("stamp_duty.next_steps.find_out_more.tips").each do |tip| %>
-      <li><%= link_to tip[:copy_html], tip[:url], target: "_blank", rel: no_follow? %></li>
+      <li class="stamp-duty__info-tip-link"><%= link_to tip[:copy_html], tip[:url], target: "_blank", rel: no_follow? %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -1,72 +1,73 @@
 <h2 class="intro stamp-duty__subheading"><%= I18n.t('stamp_duty.title') %></h2>
+<div class="stamp-duty__calculator-column">
+  <%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_two mortgagecalc__form mortgagecalc__form--pull', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
+    <div class="form__item">
+      <%= f.label :price %>
+      <div class="visually-hidden"
+            id="mc_accessibility_describe_price">
+        <%= t 'stamp_duty.describe_price_field' %>
+      </div>
 
-<%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_two mortgagecalc__form mortgagecalc__form--pull', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
-  <div class="form__item">
-    <%= f.label :price %>
-    <div class="visually-hidden"
-          id="mc_accessibility_describe_price">
-      <%= t 'stamp_duty.describe_price_field' %>
+      <span class="form__input-container">
+        <span class="form__input-label">£</span>
+        <%= f.text_field :price,
+                         :value => @stamp_duty.price_formatted,
+                         class: 'form__input dynamic-slider-property',
+                         "ng-model" => "stampDuty.propertyPrice",
+                         "placeholder" => "0.00",
+                         "currency" => '',
+                         "data-m-dec" => "0",
+                         "analytics" => "",
+                         "analytics-on" => "change",
+                         "analytics-category" => "Stamp Duty Calculator",
+                         "analytics-action" => "Refinement",
+                         "analytics-label" => "Price",
+                         "pattern" => '\d*',
+                         "aria-describedby" => 'mc_accessibility_describe_price',
+                         "autoselect" => ""
+                         %>
+        <span class="form__input-outline"></span>
+      </span>
+    </div>
+    <%= f.hidden_field :second_home %>
+
+    <div class="slider"
+          ui-slider
+          dynamic-for='dynamic-slider-property'
+          ng-model="stampDuty.propertyPrice"
+          analytics-category="Stamp Duty"
+          analytics-action="Refinement"
+          analytics-label="Price"
+          aria-hidden="true">
     </div>
 
-    <span class="form__input-container">
-      <span class="form__input-label">£</span>
-      <%= f.text_field :price,
-                       :value => @stamp_duty.price_formatted,
-                       class: 'form__input dynamic-slider-property',
-                       "ng-model" => "stampDuty.propertyPrice",
-                       "placeholder" => "0.00",
-                       "currency" => '',
-                       "data-m-dec" => "0",
-                       "analytics" => "",
-                       "analytics-on" => "change",
-                       "analytics-category" => "Stamp Duty Calculator",
-                       "analytics-action" => "Refinement",
-                       "analytics-label" => "Price",
-                       "pattern" => '\d*',
-                       "aria-describedby" => 'mc_accessibility_describe_price',
-                       "autoselect" => ""
-                       %>
-      <span class="form__input-outline"></span>
-    </span>
+    <div class="hide-with-js">
+      <p><br><%= f.submit I18n.t("stamp_duty.recalculate"),
+                          'class' => 'button',
+                          'wz-next' => '' %></p>
+    </div>
+
+  <% end %>
+
+  <%= render 'stamp_duty_to_pay_panel' if @stamp_duty.valid? %>
+
+  <div class="">
+    <h4 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h4>
+    <p><%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_calculator'),
+                   full_mortgage_calculator_url,
+                   class: "button button--primary mortgagecalc__spread",
+                   target: "_blank",
+                   rel: no_follow? %>
+
+      <%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_affordability_calculator'),
+                   full_mortgage_affordability_calculator_url,
+                   class: "button button--primary mortgagecalc__spread",
+                   target: "_blank",
+                   rel: no_follow? %></p>
   </div>
-  <%= f.hidden_field :second_home %>
-
-  <div class="slider"
-        ui-slider
-        dynamic-for='dynamic-slider-property'
-        ng-model="stampDuty.propertyPrice"
-        analytics-category="Stamp Duty"
-        analytics-action="Refinement"
-        analytics-label="Price"
-        aria-hidden="true">
-  </div>
-
-  <div class="hide-with-js">
-    <p><br><%= f.submit I18n.t("stamp_duty.recalculate"),
-                        'class' => 'button',
-                        'wz-next' => '' %></p>
-  </div>
-
-<% end %>
-
-<%= render 'stamp_duty_to_pay_panel' if @stamp_duty.valid? %>
-
-<div class="">
-  <h4 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h4>
-  <p><%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_calculator'),
-                 full_mortgage_calculator_url,
-                 class: "button button--primary mortgagecalc__spread",
-                 target: "_blank",
-                 rel: no_follow? %>
-
-    <%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_affordability_calculator'),
-                 full_mortgage_affordability_calculator_url,
-                 class: "button button--primary mortgagecalc__spread",
-                 target: "_blank",
-                 rel: no_follow? %></p>
 </div>
 
-<div class="mortgagecalc__panel">
+<div class="stamp-duty__info-column">
   <div class="callout">
     <h3 class="mortgagecalc__subheading"><%= I18n.t("stamp_duty.next_steps.learn_more.title") %></h3>
     <p><%= I18n.t("stamp_duty.next_steps.learn_more.tip_1") %></p>

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -1,74 +1,69 @@
-<div class="mortgagecalc__panel mortgagecalc__panel--with-form">
-  <div class="mortgagecalc__panel mortgagecalc__panel--full">
-    <div class="intro"><%= I18n.t('stamp_duty.title') %></div>
-    <p class="mortgagecalc__intro"><%= I18n.t('stamp_duty.page_2_description') %></p>
+<h2 class="intro stamp-duty__subheading"><%= I18n.t('stamp_duty.title') %></h2>
+
+<%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_two mortgagecalc__form mortgagecalc__form--pull', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
+  <div class="form__item">
+    <%= f.label :price %>
+    <div class="visually-hidden"
+          id="mc_accessibility_describe_price">
+      <%= t 'stamp_duty.describe_price_field' %>
+    </div>
+
+    <span class="form__input-container">
+      <span class="form__input-label">£</span>
+      <%= f.text_field :price,
+                       :value => @stamp_duty.price_formatted,
+                       class: 'form__input dynamic-slider-property',
+                       "ng-model" => "stampDuty.propertyPrice",
+                       "placeholder" => "0.00",
+                       "currency" => '',
+                       "data-m-dec" => "0",
+                       "analytics" => "",
+                       "analytics-on" => "change",
+                       "analytics-category" => "Stamp Duty Calculator",
+                       "analytics-action" => "Refinement",
+                       "analytics-label" => "Price",
+                       "pattern" => '\d*',
+                       "aria-describedby" => 'mc_accessibility_describe_price',
+                       "autoselect" => ""
+                       %>
+      <span class="form__input-outline"></span>
+    </span>
+  </div>
+  <%= f.hidden_field :second_home %>
+
+  <div class="slider"
+        ui-slider
+        dynamic-for='dynamic-slider-property'
+        ng-model="stampDuty.propertyPrice"
+        analytics-category="Stamp Duty"
+        analytics-action="Refinement"
+        analytics-label="Price"
+        aria-hidden="true">
   </div>
 
-  <%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_two mortgagecalc__form mortgagecalc__form--pull', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
-    <div class="form__item">
-      <%= f.label :price %>
-      <div class="visually-hidden"
-            id="mc_accessibility_describe_price">
-        <%= t 'stamp_duty.describe_price_field' %>
-      </div>
-
-      <span class="form__input-container">
-        <span class="form__input-label">£</span>
-        <%= f.text_field :price,
-                         :value => @stamp_duty.price_formatted,
-                         class: 'form__input dynamic-slider-property',
-                         "ng-model" => "stampDuty.propertyPrice",
-                         "placeholder" => "0.00",
-                         "currency" => '',
-                         "data-m-dec" => "0",
-                         "analytics" => "",
-                         "analytics-on" => "change",
-                         "analytics-category" => "Stamp Duty Calculator",
-                         "analytics-action" => "Refinement",
-                         "analytics-label" => "Price",
-                         "pattern" => '\d*',
-                         "aria-describedby" => 'mc_accessibility_describe_price',
-                         "autoselect" => ""
-                         %>
-        <span class="form__input-outline"></span>
-      </span>
-    </div>
-    <%= f.hidden_field :second_home %>
-
-    <div class="slider"
-          ui-slider
-          dynamic-for='dynamic-slider-property'
-          ng-model="stampDuty.propertyPrice"
-          analytics-category="Stamp Duty"
-          analytics-action="Refinement"
-          analytics-label="Price"
-          aria-hidden="true">
-    </div>
-
-    <div class="hide-with-js">
-      <p><br><%= f.submit I18n.t("stamp_duty.recalculate"),
-                          'class' => 'button',
-                          'wz-next' => '' %></p>
-    </div>
-
-  <% end %>
-
-  <%= render 'stamp_duty_to_pay_panel' if @stamp_duty.valid? %>
-
-  <div class="">
-    <h4 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h4>
-    <p><%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_calculator'),
-                   full_mortgage_calculator_url,
-                   class: "button button--primary mortgagecalc__spread",
-                   target: "_blank",
-                   rel: no_follow? %>
-
-      <%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_affordability_calculator'),
-                   full_mortgage_affordability_calculator_url,
-                   class: "button button--primary mortgagecalc__spread",
-                   target: "_blank",
-                   rel: no_follow? %></p>
+  <div class="hide-with-js">
+    <p><br><%= f.submit I18n.t("stamp_duty.recalculate"),
+                        'class' => 'button',
+                        'wz-next' => '' %></p>
   </div>
+
+<% end %>
+
+<%= render 'stamp_duty_to_pay_panel' if @stamp_duty.valid? %>
+
+<div class="">
+  <h4 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h4>
+  <p><%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_calculator'),
+                 full_mortgage_calculator_url,
+                 class: "button button--primary mortgagecalc__spread",
+                 target: "_blank",
+                 rel: no_follow? %>
+
+    <%= link_to t('stamp_duty.next_steps.have_you_tried.mortgage_affordability_calculator'),
+                 full_mortgage_affordability_calculator_url,
+                 class: "button button--primary mortgagecalc__spread",
+                 target: "_blank",
+                 rel: no_follow? %></p>
 </div>
 
 <div class="mortgagecalc__panel">

--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_payment.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_payment.html.erb
@@ -1,5 +1,0 @@
-<p ng-hide="js" class="mortgagecalc__heading mortgagecalc__payment squeeze results"><%= number_to_currency @stamp_duty.tax_due_formatted %></p>
-<p class="rendered-from-js mortgagecalc__heading mortgagecalc__payment squeeze results">{{ stampDuty.cost() | customCurrency:"£" }}</p>
-
-<p ng-hide="js" class="squeeze results-text"><%= I18n.t("stamp_duty.results.sentence", percentage: number_to_percentage(@stamp_duty.percentage_tax, precision: 1)) %></p>
-<p class="rendered-from-js squeeze results-text"><%= I18n.t("stamp_duty.results.sentence_prefix") %> {{ stampDuty.percentageTax() | number: 1 }}<%= I18n.t("stamp_duty.results.sentence_suffix") %></p>

--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
@@ -1,5 +1,5 @@
-<div>
-  <h2 class="callout__heading">
+<div class="stamp-duty__results">
+  <h2 class="stamp-duty__results-heading">
     <div ng-hide="js">
       <% key = @stamp_duty.second_home ? 'second_title' : 'title' %>
       <%= I18n.t("stamp_duty.results.#{key}") %>
@@ -8,10 +8,15 @@
       <span ng-if="stampDuty.isSecondHome"><%= I18n.t("stamp_duty.results.second_title") %></span>
       <span ng-if="!stampDuty.isSecondHome"><%= I18n.t("stamp_duty.results.title") %></span>
     </div>
+    <span ng-hide="js"><%= number_to_currency @stamp_duty.tax_due_formatted %></span>
+    <span class="rendered-from-js">{{ stampDuty.cost() | customCurrency:"£" }}</span>
   </h2>
-  <%= render 'stamp_duty_payment' %>
 
+  <p ng-hide="js" class="stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence", percentage: number_to_percentage(@stamp_duty.percentage_tax, precision: 1)) %></p>
+  <p class="rendered-from-js stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence_prefix") %> {{ stampDuty.percentageTax() | number: 1 }}<%= I18n.t("stamp_duty.results.sentence_suffix") %></p>
+</div>
 
+<div>
   <p>
     <a href="#" class="rendered-from-js expander expander--nudge" ng-class="{ 'expander--expanded' : expandedStampDutyInformation }" ng-click="toggleStampDutyExpanded($event)" affects-height="click">
       <%= I18n.t("stamp_duty.how_calculated_toggle") %>
@@ -20,4 +25,3 @@
   </p>
   <%= render 'stamp_duty_tip' %>
 </div>
-


### PR DESCRIPTION
This PR is to restyle the stamp duty calculator JS desktop view to bring it inline with the Optimizely (A-B tested) prototype.

The PRs related to this work are:
- [Removing Page 3 and links to it](https://github.com/moneyadviceservice/mortgage_calculator/pull/266)
- [Add items to second screen of stamp duty calculator](https://github.com/moneyadviceservice/mortgage_calculator/pull/267)
- Style Desktop JS (this PR)
- Style Tablet JS
- Style Mobile JS
- Style Non-JS Desktop

**Before**
![screen shot 2016-11-30 at 14 05 23](https://cloud.githubusercontent.com/assets/67151/20755559/5519b792-b707-11e6-928d-ec8ed6586f33.png)

**After**
![screen shot 2016-11-30 at 14 12 47](https://cloud.githubusercontent.com/assets/67151/20755562/5682207e-b707-11e6-98e9-a62d0e5c88d6.png)
