### PR TITLE
Stamp Duty Calculator: Style Tablet JS Version

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -1,3 +1,13 @@
+@mixin stamp-duty__col {
+  display: inline;
+  float: left;
+  width: 100%;
+
+  @include respond-to($mortgagecalc_mq-m) {
+    width: 50%;
+  }
+}
+
 .stamp-duty__step-one {
   margin-top: 0;
 
@@ -140,13 +150,10 @@ input.stamp-duty__input {
 }
 
 .stamp-duty__calculator-column {
-  display: inline;
-  float: left;
-  width: 100%;
+  @include stamp-duty__col;
   margin-top: $baseline-unit*2;
 
   @include respond-to($mortgagecalc_mq-m) {
-    width: 50%;
     border-right: 1px solid $color-grey-pale;
     padding-right: $baseline-unit*4;
     margin-bottom: $baseline-unit*4;
@@ -154,12 +161,9 @@ input.stamp-duty__input {
 }
 
 .stamp-duty__info-column {
-  display: inline;
-  float: left;
-  width: 100%;
+  @include stamp-duty__col;
 
   @include respond-to($mortgagecalc_mq-m) {
-    width: 50%;
     padding-left: $baseline-unit*4;
     margin-top: $baseline-unit*2;
   }

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -187,7 +187,11 @@ input.stamp-duty__input {
 }
 
 .stamp-duty__button {
-  width: 100%;
+  width: 48%;
+
+  @include respond-to($mortgagecalc_mq-m) {
+    width: 100%;
+  }
 }
 
 .stamp-duty__info-subheading {

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -142,22 +142,27 @@ input.stamp-duty__input {
 .stamp-duty__calculator-column {
   display: inline;
   float: left;
-  width: 50%;
-
+  width: 100%;
   margin-top: $baseline-unit*2;
 
-  border-right: 1px solid $color-grey-pale;
-  padding-right: $baseline-unit*4;
-  margin-bottom: $baseline-unit*4;
+  @include respond-to($mortgagecalc_mq-m) {
+    width: 50%;
+    border-right: 1px solid $color-grey-pale;
+    padding-right: $baseline-unit*4;
+    margin-bottom: $baseline-unit*4;
+  }
 }
 
 .stamp-duty__info-column {
   display: inline;
   float: left;
-  width: 50%;
+  width: 100%;
 
-  padding-left: $baseline-unit*4;
-  margin-top: $baseline-unit*2;
+  @include respond-to($mortgagecalc_mq-m) {
+    width: 50%;
+    padding-left: $baseline-unit*4;
+    margin-top: $baseline-unit*2;
+  }
 }
 
 .stamp-duty__results {


### PR DESCRIPTION
This PR is to restyle the stamp duty calculator JS tablet view to bring it inline with the Optimizely (A-B tested) prototype.

The PRs related to this work are:

- [Removing Page 3 and links to it](https://github.com/moneyadviceservice/mortgage_calculator/pull/266)
- [Add items to second screen of stamp duty calculator](https://github.com/moneyadviceservice/mortgage_calculator/pull/267)
- [Style Desktop JS](https://github.com/moneyadviceservice/mortgage_calculator/pull/268)
- Style Tablet JS (this PR)
- Style Mobile JS
- Style Non-JS Desktop

**Before**
![screen shot 2016-12-01 at 08 58 42](https://cloud.githubusercontent.com/assets/67151/20787752/6d0e0de6-b7a5-11e6-89b4-f837db2aaa87.png)

**After**
![screen shot 2016-12-01 at 08 58 50](https://cloud.githubusercontent.com/assets/67151/20787757/73898fa6-b7a5-11e6-85a9-5775f783ee10.png)
