### PR TITLE
Stamp Duty Calculator: Style Mobile JS Version

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -151,7 +151,10 @@ input.stamp-duty__input {
 
 .stamp-duty__calculator-column {
   @include stamp-duty__col;
-  margin-top: $baseline-unit*2;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    margin-top: $baseline-unit*2;
+  }
 
   @include respond-to($mortgagecalc_mq-m) {
     border-right: 1px solid $color-grey-pale;

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -194,7 +194,11 @@ input.stamp-duty__input {
 }
 
 .stamp-duty__button {
-  width: 48%;
+  width: 100%;
+
+  @include respond-to($mortgagecalc_mq-s) {
+    width: 48%;
+  }
 
   @include respond-to($mortgagecalc_mq-m) {
     width: 100%;

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -178,11 +178,15 @@ input.stamp-duty__input {
 }
 
 .stamp-duty__results-heading {
+  @include body(16,30);
+
   color: $color-true-black;
   font-weight: 500;
   display: inline;
 
-  @include body(24,36);
+  @include respond-to($mortgagecalc_mq-s) {
+    @include body(24,36);
+  }
 }
 
 .stamp-duty__results-tax-rate {


### PR DESCRIPTION
This PR is to restyle the stamp duty calculator JS mobile view to bring it inline with the Optimizely (A-B tested) prototype.

The PRs related to this work are:

[Removing Page 3 and links to it](https://github.com/moneyadviceservice/mortgage_calculator/pull/266)
[Add items to second screen of stamp duty calculator](https://github.com/moneyadviceservice/mortgage_calculator/pull/267)
[Style Desktop JS](https://github.com/moneyadviceservice/mortgage_calculator/pull/268)
[Style Tablet JS](https://github.com/moneyadviceservice/mortgage_calculator/pull/269)
Style Mobile JS  (this PR)
Style Non-JS Desktop

**Before**
![screen shot 2016-12-01 at 11 43 03](https://cloud.githubusercontent.com/assets/67151/20793176/ac2b729e-b7bd-11e6-895b-630cc305293d.png)


**After**
![screen shot 2016-12-01 at 11 53 35](https://cloud.githubusercontent.com/assets/67151/20793182/b479dfa8-b7bd-11e6-8fd0-ecf8bef12d9d.png)
