### PR TITLE
[DEV APPROVED]Stamp Duty Calculator: Style desktop non-JS Version

### DIFF
--- a/app/views/mortgage_calculator/stamp_duties/create.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/create.html.erb
@@ -1,4 +1,4 @@
-<div class="mortgagecalc__container">
+<div class="stamp-duty">
   <%= render 'header' %>
   <%= render 'form_step2' %>
 </div>


### PR DESCRIPTION
This PR is to restyle the stamp duty calculator non JS desktop view to bring it inline with the Optimizely (A-B tested) prototype.

The PRs related to this work are:

[Removing Page 3 and links to it](https://github.com/moneyadviceservice/mortgage_calculator/pull/266)
[Add items to second screen of stamp duty calculator](https://github.com/moneyadviceservice/mortgage_calculator/pull/267)
[Style Desktop JS](https://github.com/moneyadviceservice/mortgage_calculator/pull/268)
[Style Tablet JS ](https://github.com/moneyadviceservice/mortgage_calculator/pull/269)
[Style Mobile JS](https://github.com/moneyadviceservice/mortgage_calculator/pull/270)
Style Non-JS Desktop (this PR)

**Before**

![screencapture-localhost-5000-en-tools-house-buying-stamp-duty-calculator-1480595094064](https://cloud.githubusercontent.com/assets/67151/20794086/3985c29e-b7c2-11e6-861e-1fc02288c288.png)


**After**

![screen shot 2016-12-01 at 12 29 15](https://cloud.githubusercontent.com/assets/67151/20794097/421c43ba-b7c2-11e6-8069-36ab92052aee.png)

