### PR TITLE
[DEV APPROVED] - Adding unique id on form on second page of stamp duty calc

### DIFF
--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -1,6 +1,6 @@
 <h2 class="intro stamp-duty__subheading"><%= I18n.t('stamp_duty.title') %></h2>
 <div class="stamp-duty__calculator-column">
-  <%= form_for @stamp_duty, url: stamp_duty_path, html: { name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
+  <%= form_for @stamp_duty, url: stamp_duty_path, html: { id: 'update_stamp_duty', name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
     <div class="form__item stamp-duty__form">
       <%= f.label :price, class: 'stamp-duty__input-description' %>
       <div class="visually-hidden"


### PR DESCRIPTION
This PR is to fix an pre-existing accessibility issue where the first and second pages of the stamp duty calculator forms share an id. This confuses screen readers, so we changed the id of the second form.