### PR TITLE
Updates to second page of stamp duty calc

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.stamp-duty--white {
+  background-color: white;
+}
+
 .stamp-duty__heading {
   @include body(24,36);
   margin-top: $baseline-unit*4;
@@ -217,4 +221,8 @@ p.stamp-duty__info-tip {
 
 .stamp-duty__info-tip-link {
   @include body(16,24)
+}
+
+.stamp-duty__table {
+  margin-bottom: 0;
 }

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -151,6 +151,7 @@ input.stamp-duty__input {
 
 .stamp-duty__have-you-tried {
   @include body(20, 24);
+  margin-top: $baseline-unit*5;
 }
 
 .stamp-duty__calculator-column {

--- a/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
@@ -1,47 +1,46 @@
 <p><%= I18n.t("stamp_duty.how_calculated") %></p>
 <p><%= I18n.t("stamp_duty.how_calculated_additional") %></p>
-<div class="table-wrapper">
-  <table class="mortgagecalc__table">
-    <thead>
-      <tr>
-        <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
-        <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
-        <th class="mortgagecalc__table__extra"><%= I18n.t("stamp_duty.table.extra_rate_header") %></th>
-      </tr>
-    </thead>
+<table class="mortgagecalc__table stamp-duty__table">
+  <thead>
+    <tr>
+      <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
+      <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
+      <th class="mortgagecalc__table__extra"><%= I18n.t("stamp_duty.table.extra_rate_header") %></th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td class="mortgagecalc__table__price">&pound;0 - &pound;125,000</td>
-        <td class="mortgagecalc__table__rate">0%</td>
-        <td class="mortgagecalc__table__extra">3%</td>
-      </tr>
+  <tbody>
+    <tr>
+      <td class="mortgagecalc__table__price">&pound;0 - &pound;125,000</td>
+      <td class="mortgagecalc__table__rate">0%</td>
+      <td class="mortgagecalc__table__extra">3%</td>
+    </tr>
 
-      <tr>
-        <td class="mortgagecalc__table__price">&pound;125,001 - &pound;250,000</td>
-        <td class="mortgagecalc__table__rate">2%</td>
-        <td class="mortgagecalc__table__extra">5%</td>
-      </tr>
+    <tr>
+      <td class="mortgagecalc__table__price">&pound;125,001 - &pound;250,000</td>
+      <td class="mortgagecalc__table__rate">2%</td>
+      <td class="mortgagecalc__table__extra">5%</td>
+    </tr>
 
-      <tr>
-        <td class="mortgagecalc__table__price">&pound;250,001 - &pound;925,000</td>
-        <td class="mortgagecalc__table__rate">5%</td>
-        <td class="mortgagecalc__table__extra">8%</td>
-      </tr>
+    <tr>
+      <td class="mortgagecalc__table__price">&pound;250,001 - &pound;925,000</td>
+      <td class="mortgagecalc__table__rate">5%</td>
+      <td class="mortgagecalc__table__extra">8%</td>
+    </tr>
 
-      <tr>
-        <td class="mortgagecalc__table__price">&pound;925,001 - &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
-        <td class="mortgagecalc__table__rate">10%</td>
-        <td class="mortgagecalc__table__extra">13%</td>
-      </tr>
+    <tr>
+      <td class="mortgagecalc__table__price">&pound;925,001 - &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
+      <td class="mortgagecalc__table__rate">10%</td>
+      <td class="mortgagecalc__table__extra">13%</td>
+    </tr>
 
-      <tr>
-        <td class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.over") %> &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
-        <td class="mortgagecalc__table__rate">12%</td>
-        <td class="mortgagecalc__table__extra">15%</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+    <tr>
+      <td class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.over") %> &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
+      <td class="mortgagecalc__table__rate">12%</td>
+      <td class="mortgagecalc__table__extra">15%</td>
+    </tr>
+  </tbody>
+</table>
+
 
 <p><%= I18n.t("stamp_duty.how_calculated_extra") %></p>

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -71,6 +71,7 @@
   <div class="callout">
     <div class="stamp-duty__info-subheading"><%= I18n.t("stamp_duty.next_steps.learn_more.title") %></div>
     <p class="stamp-duty__info-tip"><%= I18n.t("stamp_duty.next_steps.learn_more.tip_1") %></p>
+    <p><a class="stamp-duty__info-tip-link" href="<%= I18n.t("stamp_duty.next_steps.learn_more.link_1.url") %>"><%= I18n.t("stamp_duty.next_steps.learn_more.link_1.title") %></a>
   </div>
 
   <h3 class="mortgagecalc__subheading"><%= I18n.t("stamp_duty.next_steps.find_out_more.title") %>:</h3>

--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_tip.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_tip.html.erb
@@ -1,5 +1,7 @@
-<div class="mortgagecalc__panel mortgagecalc__panel--full">
+<div class="mortgagecalc__panel--full">
   <div ng-show="expandedStampDutyInformation" class="mortgagecalc__tip">
-    <%= render 'bands_table' %>
+    <div class="stamp-duty stamp-duty--white">
+      <%= render 'bands_table' %>
+    </div>
   </div>
 </div>

--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
@@ -14,14 +14,15 @@
 
   <p ng-hide="js" class="stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence", percentage: number_to_percentage(@stamp_duty.percentage_tax, precision: 1)) %></p>
   <p class="rendered-from-js stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence_prefix") %> {{ stampDuty.percentageTax() | number: 1 }}<%= I18n.t("stamp_duty.results.sentence_suffix") %></p>
-</div>
 
-<div>
-  <p>
-    <a href="#" class="rendered-from-js expander expander--nudge" ng-class="{ 'expander--expanded' : expandedStampDutyInformation }" ng-click="toggleStampDutyExpanded($event)" affects-height="click">
-      <%= I18n.t("stamp_duty.how_calculated_toggle") %>
-      <span class="visually-hidden"><%= I18n.t("stamp_duty.results.click_to_expand") %></span>
-    </a>
-  </p>
-  <%= render 'stamp_duty_tip' %>
+  <div>
+
+    <p>
+      <a href="#" class="rendered-from-js expander expander--nudge" ng-class="{ 'expander--expanded' : expandedStampDutyInformation }" ng-click="toggleStampDutyExpanded($event)" affects-height="click">
+        <%= I18n.t("stamp_duty.how_calculated_toggle") %>
+        <span class="visually-hidden"><%= I18n.t("stamp_duty.results.click_to_expand") %></span>
+      </a>
+    </p>
+    <%= render 'stamp_duty_tip' %>
+  </div>
 </div>

--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
@@ -16,13 +16,10 @@
   <p class="rendered-from-js stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence_prefix") %> {{ stampDuty.percentageTax() | number: 1 }}<%= I18n.t("stamp_duty.results.sentence_suffix") %></p>
 
   <div>
-
-    <p>
-      <a href="#" class="rendered-from-js expander expander--nudge" ng-class="{ 'expander--expanded' : expandedStampDutyInformation }" ng-click="toggleStampDutyExpanded($event)" affects-height="click">
-        <%= I18n.t("stamp_duty.how_calculated_toggle") %>
-        <span class="visually-hidden"><%= I18n.t("stamp_duty.results.click_to_expand") %></span>
-      </a>
-    </p>
+    <a href="#" class="rendered-from-js expander expander--nudge" ng-class="{ 'expander--expanded' : expandedStampDutyInformation }" ng-click="toggleStampDutyExpanded($event)" affects-height="click">
+      <%= I18n.t("stamp_duty.how_calculated_toggle") %>
+      <span class="visually-hidden"><%= I18n.t("stamp_duty.results.click_to_expand") %></span>
+    </a>
     <%= render 'stamp_duty_tip' %>
   </div>
 </div>

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -48,6 +48,9 @@ cy:
       learn_more:
         title: "A wyddech chi?"
         tip_1: "Rhaid i chi dalu Treth Stamp cyn pen 30 diwrnod ar ol prynu eiddo. Os ydych yn defnyddio cyfreithiwr i gwblhau'r trawsgludo, bydd fel arfer yn trefnu'r taliad ar eich rhan"
+        link_1:
+          title: Treth Stamp - Popeth sydd angen i chi wybod
+          url: "/cy/articles/popeth-sydd-angen-ichi-ei-wybod-am-y-dreth-stamp"
       find_out_more:
         title: "Darganfyddwch fwy"
         tips:

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -47,6 +47,9 @@ en:
       learn_more:
         title: "Did you know?"
         tip_1: "You have to pay Stamp Duty within 30 days of buying a property. If you're using a solicitor to carry out the conveyancing, they will normally organise the payment for you."
+        link_1:
+          title: Stamp Duty - Everything you need to know
+          url: "/en/articles/everything-you-need-to-know-about-stamp-duty"
       find_out_more:
         title: Find out more
         tips:

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -19,7 +19,7 @@ en:
     how_calculated_toggle: "How is this calculated?"
     how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400 giving an effective tax rate of 1%."
     how_calculated_additional: "As of April 2016, anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
-    how_calculated_extra: "*Properties under £40,000 are not subject to second home SDLT"
+    how_calculated_extra: "* Properties under £40,000 are not subject to second home SDLT"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:
       attributes:


### PR DESCRIPTION
Last minute changes arrived today as we were pushing through the other 6 main PRs.

Here we have:
- Pulled the 'How is this calculated?' and associated expanding explanation section into the results callout box.
- Added "Stamp Duty - Everything you need to know" link to the "Did you know?" callout section.

**Before**

![screen shot 2016-12-01 at 17 17 44](https://cloud.githubusercontent.com/assets/67151/20804303/495ada06-b7ea-11e6-97da-0713fc9749fa.png)

**After: Unexpanded**

![screen shot 2016-12-01 at 17 16 06](https://cloud.githubusercontent.com/assets/67151/20804362/80596270-b7ea-11e6-8b85-7f00999c3275.png)


**After: Expanded**

![screencapture-localhost-5000-en-tools-house-buying-stamp-duty-calculator-1480613066600](https://cloud.githubusercontent.com/assets/67151/20804493/0aaec6a4-b7eb-11e6-8860-284b3c799eda.png)
