### PR TITLE
[DEV APPROVED] Resolve highlight focus issue on input

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -55,6 +55,7 @@
 .stamp-duty__form {
   margin-top: 0;
   overflow: hidden;
+  padding: $baseline-unit;
 
   @include respond-to($mortgagecalc_mq-s) {
     margin: 0 0 $baseline-unit*3;


### PR DESCRIPTION
While doing QA on Firefox we noticed the focus highlight on the input was being cut off. Adding a small amount of padding to the stamp-duty__form resolves this on both pages of the Stamp Duty Calculator.

**Before:**

![screen shot 2016-12-02 at 11 24 12](https://cloud.githubusercontent.com/assets/11137272/20832473/660d04d8-b882-11e6-9ead-2e0b9ce2617e.png)
![screen shot 2016-12-02 at 11 24 53](https://cloud.githubusercontent.com/assets/11137272/20832476/69cbaf66-b882-11e6-9763-c4d92cdd3b94.png)


**After:**

![screen shot 2016-12-02 at 11 24 21](https://cloud.githubusercontent.com/assets/11137272/20832494/78929294-b882-11e6-9bc3-6a2cc9ddb9d2.png)
![screen shot 2016-12-02 at 11 24 40](https://cloud.githubusercontent.com/assets/11137272/20832495/7a8506cc-b882-11e6-9336-9629ad6b3174.png)
