### PR TITLE
[DEV APPROVED]Add configuration of slider on click of "Next" button on previous page

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/directives/slider.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/directives/slider.js
@@ -123,16 +123,23 @@ App.directive('uiSlider', function() {
     angular.extend(options, expression);
     element.slider(options).on('slide', options.slide);
 
-    //Reconfigre slider when input blurs
+    angular.element('.stamp-duty__submit').on('click', function() {
+      reconfigureSlider();
+    });
+
     input.on('blur keyup', function() {
-      value = parseInt($(this).val().replace(/[^\d|\-+|\.+]/g, '')) || 0;
+      reconfigureSlider();
+    });
+
+    function reconfigureSlider() {
+      value = parseInt($(input).val().replace(/[^\d|\-+|\.+]/g, '')) || 0;
       element.slider({
         min: (percentageForMin / 100) * value,
         max: ((percentageForMax / 100) * value) || sliderDefaultMax,
         value: value,
         step: (value / 100) * 1
       });
-    });
+    }
 
     setTimeout(function() {
       element.trigger('slide');


### PR DESCRIPTION
When using the 'Next' button from the first page of the Stamp Duty calculator to navigate to the second page, the slider was not reconfiguring correctly to use the value from the input box.

We've refactored the functionality previously within ```input.on('blur keyup', function()``` out into ```reconfigureSlider()``` so that we can make use of it in the context of both events. 

First page - button being targeted:
![screen shot 2016-12-06 at 16 53 42](https://cloud.githubusercontent.com/assets/11137272/20934943/d60a89c2-bbd4-11e6-8750-8715a78bdbb1.png)

Second page before - slider configured incorrectly:
![screen shot 2016-12-06 at 16 53 52](https://cloud.githubusercontent.com/assets/11137272/20934944/d79e04ee-bbd4-11e6-8f1a-cd9459681b1e.png)

Second page after - slider now correctly configured as soon as second page loads:
![screen shot 2016-12-06 at 16 54 02](https://cloud.githubusercontent.com/assets/11137272/20934945/d936e492-bbd4-11e6-9c06-686c0ea82908.png)
