### PR TITLE
[DEV APPROVED] TP: 7934, Comment: Updates markup and styles for mortgage tools

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_callout.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_callout.scss
@@ -2,14 +2,12 @@
   font-family: 'museo_sans';
   font-weight: 500;
   margin: 10px 0 30px;
-  padding: 0 $baseline-unit*3 $baseline-unit*3;
 
   p {
     font-family: 'museo_sans';
     font-weight: 300;
     font-size: $font-medium;
     color: #333;
-    margin: 10px 0 0;
 
     strong {
       font-size:px(24);
@@ -19,17 +17,5 @@
 
   h3 {
     margin-left: 0;
-  }
-}
-
-.mortgagecalc__panel,
-.affcalc__col--33 .callout {
-  .callout__heading {
-    margin-top: 0;
-    margin-bottom: 10px;
-    font-family: 'museo_sans';
-    font-weight: 700;
-    color: #333;
-    font-size: $font-large;
   }
 }

--- a/app/assets/stylesheets/mortgage_calculator/components/_callout.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_callout.scss
@@ -2,8 +2,7 @@
   font-family: 'museo_sans';
   font-weight: 500;
   margin: 10px 0 30px;
-  padding: $baseline-unit*3;
-  background-color: $color-callout-background;
+  padding: 0 $baseline-unit*3 $baseline-unit*3;
 
   p {
     font-family: 'museo_sans';
@@ -23,11 +22,13 @@
   }
 }
 
-.callout__heading {
-  margin-top: 0;
-  margin-bottom: 10px;
-  font-family: 'museo_sans';
-  font-weight: 700;
-  color: #333;
-  font-size: $font-large;
+.mortgagecalc__panel {
+  .callout__heading {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-family: 'museo_sans';
+    font-weight: 700;
+    color: #333;
+    font-size: $font-large;
+  }
 }

--- a/app/assets/stylesheets/mortgage_calculator/components/_callout.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_callout.scss
@@ -22,7 +22,8 @@
   }
 }
 
-.mortgagecalc__panel {
+.mortgagecalc__panel,
+.affcalc__col--33 .callout {
   .callout__heading {
     margin-top: 0;
     margin-bottom: 10px;

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -215,7 +215,6 @@ input.stamp-duty__input {
 .stamp-duty__info-subheading {
   @include body(24,24);
   font-weight: 700;
-  color: $color-green-secondary;
 }
 
 p.stamp-duty__info-tip {

--- a/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
@@ -13,7 +13,7 @@
     <div class="callout callout--tip">
       <span class="callout__icon" aria-hidden="true">?</span>
 
-      <h5 class="callout__heading"><%= t("affordability.next_steps.learn_more.title") %>:</h5>
+      <h5 class="callout__heading"><%= t("affordability.next_steps.learn_more.title") %></h5>
 
       <% (1..2).each do |i| %>
         <p><%= t("affordability.next_steps.learn_more.tip_#{i}") %></p>

--- a/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
@@ -10,8 +10,10 @@
 
 <div class="affcalc__row">
   <div class="affcalc__col--33">
-    <div class="callout">
-      <h5 class="mortgagecalc__subheading"><%= t("affordability.next_steps.learn_more.title") %>:</h5>
+    <div class="callout callout--tip">
+      <span class="callout__icon" aria-hidden="true">?</span>
+
+      <h5 class="callout__heading"><%= t("affordability.next_steps.learn_more.title") %>:</h5>
 
       <% (1..2).each do |i| %>
         <p><%= t("affordability.next_steps.learn_more.tip_#{i}") %></p>

--- a/app/views/mortgage_calculator/repayments/_calc_left_panel.html.erb
+++ b/app/views/mortgage_calculator/repayments/_calc_left_panel.html.erb
@@ -9,7 +9,8 @@
     <%= render 'tabs' %>
   </div>
 
-  <div class="callout">
+  <div class="callout callout--tip">
+    <span class="callout__icon" aria-hidden="true">?</span>
     <h5 class="callout__heading"><%= I18n.t("mortgage_calculator.repayment.interest_changer.title") %></h5>
     <p><%= raw I18n.t("mortgage_calculator.repayment.interest_changer.intro", change: 3) %></p>
 

--- a/app/views/mortgage_calculator/repayments/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/repayments/_form_step1.html.erb
@@ -52,8 +52,9 @@
   </div>
 
   <div class="mortgagecalc__panel">
-    <div ng-class="{ 'visibly-hidden' : !repayments.deposit }" class="callout">
-      <%= I18n.t("mortgage_calculator.repayment.tips.hidden_costs") %>
+    <div ng-class="{ 'visibly-hidden' : !repayments.deposit }" class="callout callout--tip">
+      <span class="callout__icon" aria-hidden="true">?</span>
+      <p><%= I18n.t("mortgage_calculator.repayment.tips.hidden_costs") %></p>
     </div>
 
     <%= f.submit I18n.t("mortgage_calculator.repayment.next"),

--- a/app/views/mortgage_calculator/repayments/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/repayments/_next_steps_content.html.erb
@@ -11,7 +11,7 @@
 <div class="mortgagecalc__panel">
   <div class="callout callout--tip">
     <span class="callout__icon" aria-hidden="true">?</span>
-    <h5 class="callout__heading"><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.title") %>:</h5>
+    <h5 class="callout__heading"><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.title") %></h5>
     <p><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.tip_1").html_safe %> <%= link_to t("mortgage_calculator.repayment.next_steps.learn_more.more.copy_html"), I18n.t("mortgage_calculator.repayment.next_steps.learn_more.more.url"), target: "_blank", rel: no_follow? %></p>
   </div>
 </div>

--- a/app/views/mortgage_calculator/repayments/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/repayments/_next_steps_content.html.erb
@@ -9,8 +9,9 @@
 </div>
 
 <div class="mortgagecalc__panel">
-  <div class="callout">
-    <h5 class="mortgagecalc__subheading"><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.title") %>:</h5>
+  <div class="callout callout--tip">
+    <span class="callout__icon" aria-hidden="true">?</span>
+    <h5 class="callout__heading"><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.title") %>:</h5>
     <p><%= I18n.t("mortgage_calculator.repayment.next_steps.learn_more.tip_1").html_safe %> <%= link_to t("mortgage_calculator.repayment.next_steps.learn_more.more.copy_html"), I18n.t("mortgage_calculator.repayment.next_steps.learn_more.more.url"), target: "_blank", rel: no_follow? %></p>
   </div>
 </div>

--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -68,8 +68,9 @@
 </div>
 
 <div class="stamp-duty__info-column">
-  <div class="callout">
-    <div class="stamp-duty__info-subheading"><%= I18n.t("stamp_duty.next_steps.learn_more.title") %></div>
+  <div class="callout callout--tip">
+    <span class="callout__icon" aria-hidden="true">?</span>
+    <div class="stamp-duty__info-subheading callout__heading"><%= I18n.t("stamp_duty.next_steps.learn_more.title") %></div>
     <p class="stamp-duty__info-tip"><%= I18n.t("stamp_duty.next_steps.learn_more.tip_1") %></p>
     <p><a class="stamp-duty__info-tip-link" href="<%= I18n.t("stamp_duty.next_steps.learn_more.link_1.url") %>"><%= I18n.t("stamp_duty.next_steps.learn_more.link_1.title") %></a>
   </div>

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,8 +1,8 @@
 module MortgageCalculator
   module Version
     MAJOR = 1
-    MINOR = 6
-    PATCH = 4
+    MINOR = 7
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
This updates the callouts on: 
- Mortgage Calculator
- Stamp Duty Calculator
- Mortgage Affordability Calculator

Also requires PR31 on Yeast - https://github.com/moneyadviceservice/yeast/pull/31 

On **Mortgage Calculator** the callouts are changed on three page views: 

**First page:** 

![image](https://cloud.githubusercontent.com/assets/6080548/23304028/8de9ddec-fa8f-11e6-8989-00080166a0f7.png)

![image](https://cloud.githubusercontent.com/assets/6080548/23304036/94fcbb4a-fa8f-11e6-84bb-8457664cd587.png)

**Second page:** 

![image](https://cloud.githubusercontent.com/assets/6080548/23304114/fba8a3ae-fa8f-11e6-9677-f338d14117d4.png)

![image](https://cloud.githubusercontent.com/assets/6080548/23459631/24b57eb0-fe79-11e6-8061-5abe277b3680.png)

**Final page:** 

![image](https://cloud.githubusercontent.com/assets/6080548/23304192/540e4e54-fa90-11e6-9365-e25ce98d3237.png)

![image](https://cloud.githubusercontent.com/assets/6080548/23459670/4ab33c4c-fe79-11e6-989e-aeb6a614da81.png)

On **Stamp Duty Calculator** there is one change to a callout:

![image](https://cloud.githubusercontent.com/assets/6080548/23367594/af4e2464-fd02-11e6-8e5c-856c2347e366.png)

![image](https://cloud.githubusercontent.com/assets/6080548/23459700/72e25fe0-fe79-11e6-95bf-58c2a35a60e7.png)

On **Mortgage Affordability Calculator** there is one change to a callout:

![image](https://cloud.githubusercontent.com/assets/6080548/23369773/6223572e-fd0a-11e6-875c-dfce3cbe631f.png)

![image](https://cloud.githubusercontent.com/assets/6080548/23459738/9b68eac4-fe79-11e6-90d8-a3968d2cca19.png)
 


