### PR TITLE
Updating mortgage calc version with minor bump

### DIFF
--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 1
-    MINOR = 7
+    MINOR = 8
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
I forgot to update the version of the mortgage calculator for the PR:

https://github.com/moneyadviceservice/mortgage_calculator/pull/280

