### PR TITLE
Removing sticky functionality

### DIFF
--- a/app/views/mortgage_calculator/repayments/_calc_left_panel.html.erb
+++ b/app/views/mortgage_calculator/repayments/_calc_left_panel.html.erb
@@ -1,12 +1,3 @@
 <div>
-
-  <div ng-docker
-       ng-docked="docked"
-       ng-docker-hide="560"
-       control="dockerControl"
-       docker-ready="{{dockerReady}}"
-       ng-cloak>
-    <%= render 'tabs' %>
-  </div>
-  
+  <%= render 'tabs' %>  
 </div>


### PR DESCRIPTION
## Removing sticky section

The mortgage calculator tool originally had a sticky tabs section that sticks to the top of the view.  However the results of the A/B test suggested that it was a better user experience to add the callout to the tabs.  Which causes the tabs to take up more than half of the view on a mobile screen:

<img src="https://cloud.githubusercontent.com/assets/13165846/23851407/5a7fe1d2-07db-11e7-8aad-6e9dc0e44d1a.png" width="300" />

This PR removes the functionality to apply the sticky tabs to the top of the viewport.

For reference this is how it appeared before:

<img src="https://cloud.githubusercontent.com/assets/13165846/23851602/fa9c87ce-07db-11e7-837f-97178810c5c4.png" width="300" />

The functionality has not been removed completely, just from the repayment calculator, as it is still used by the affordability calculator which is also part of this project.