### PR TITLE
[DEV APPROVED] 8055 - Stamp duty calculator NTY update

### DIFF
--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -10,8 +10,8 @@ cy:
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl"
     second_subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy. Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
     subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000 (£40,000 ar gyfer cartrefi ychwanegol). Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy."
-    subtitle_legislation_change: "O 1 Ebrill 2016 bydd unrhyw un sy'n prynu cartref ychwanegol gan gynnwys eiddo prynu i osod yn gorfod talu ffi ychwanegol o 3% ar ben pob band treth stamp."
-    second_subtitle: "Mae Treth Trafodion Tir ac Adeiladau (LBTT) wedi disodli Treth Stamp yn yr Alban. Bydd trethi LBTT yn destun ffi ychwanegol o 3% hefyd ar gyfer ail gartrefi o fis Ebrill 2016 ymlaen."
+    subtitle_legislation_change: "Bydd unrhyw un sy'n prynu cartref ychwanegol gan gynnwys eiddo prynu i osod yn gorfod talu ffi ychwanegol o 3% ar ben pob band treth stamp."
+    second_subtitle: "Mae Treth Trafodion Tir ac Adeiladau (LBTT) wedi disodli Treth Stamp yn yr Alban. Bydd trethi LBTT yn destun ffi ychwanegol o 3% hefyd ar gyfer ail gartrefi."
     href_second_subtitle: "Cyfrifwch yr LBTT sy'n daladwy"
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
     legislation_change: "Cyn 4 Rhagfyr 2014, roeddech yn talu Treth Stamp ar un gyfradd ar y pris prynu cyfan. Os bu i chi gyfnewid cytundebau erbyn hanner nos ar 3 Rhagfyr a chwblhau'r trafodion ar 4 Rhagfyr neu'n hwyrach, gallwch ddewis talu Treth Stamp ar yr hen gyfraddau neu'r rhai newydd."
@@ -19,7 +19,7 @@ cy:
     recalculate: Ailgyfrifo
     how_calculated_toggle: "Sut y cyfrifir hyn?"
     how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n prynu eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp gan roi cyfradd dreth effeithiol o 1%."
-    how_calculated_additional: "O fis Ebrill 2016, bydd unrhyw un sy'n prynu ail gartref, gan gynnwys eiddo prynu i osod, yn talu 3% ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny'n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750, gan roi cyfradd dreth effeithiol o 4%."
+    how_calculated_additional: "Bydd unrhyw un sy'n prynu ail gartref, gan gynnwys eiddo prynu i osod, yn talu 3% ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny'n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750, gan roi cyfradd dreth effeithiol o 4%."
     how_calculated_extra: "*Nid yw eiddo dan £40,000 yn destun SDLT ail gartref"
     describe_price_field: Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn.
     activemodel:
@@ -41,7 +41,7 @@ cy:
     table:
       property_price_header: "Pris Prynu"
       rate_header: "Cyfradd treth stamp"
-      extra_rate_header: "Cyfradd Prynu i Werthu neu Gartref Ychwanegol (o Ebrill 2016) *"
+      extra_rate_header: "Cyfradd Prynu i Werthu neu Gartref Ychwanegol *"
       over: Dros
       million: miliwn
     next_steps:

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -9,8 +9,8 @@ en:
     h1: Stamp Duty calculator
     title: Calculate the Stamp Duty on your residential property
     subtitle: "Calculate the Stamp Duty on your residential property in England, Wales or Northern Ireland. You have to pay Stamp Duty (SDLT) if you buy a property costing more than £125,000 (£40,000 for additional homes). Use this calculator to work out how much Stamp Duty is payable."
-    subtitle_legislation_change: "From the 1st April 2016 anyone purchasing an additional home including buy to let properties will have to pay an extra 3% surcharge on top of each stamp duty band."
-    second_subtitle: "Land and Buildings Transaction Tax (LBTT) has replaced Stamp Duty in Scotland. LBTT rates will also attract a 3% surcharge for second homes from 1st April 2016."
+    subtitle_legislation_change: "Anyone purchasing an additional home including buy to let properties will have to pay an extra 3% surcharge on top of each stamp duty band."
+    second_subtitle: "Land and Buildings Transaction Tax (LBTT) has replaced Stamp Duty in Scotland. LBTT rates will also attract a 3% surcharge for second homes."
     href_second_subtitle: "Calculate the LBTT payable."
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
     legislation_change: "Before 4 December 2014, you paid Stamp Duty at a single rate on the whole purchase price. If you exchanged contracts by midnight on 3 December and the transaction completes on 4 December or later, you can choose whether you pay Stamp Duty at the old or new rates."
@@ -18,7 +18,7 @@ en:
     recalculate: Recalculate
     how_calculated_toggle: "How is this calculated?"
     how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400 giving an effective tax rate of 1%."
-    how_calculated_additional: "As of April 2016, anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
+    how_calculated_additional: "Anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
     how_calculated_extra: "* Properties under £40,000 are not subject to second home SDLT"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:
@@ -40,7 +40,7 @@ en:
     table:
       property_price_header: "Purchase price of property"
       rate_header: "Rate of Stamp Duty"
-      extra_rate_header: "Buy to Let/ Additional Home Rate (from April 2016) *"
+      extra_rate_header: "Buy to Let/ Additional Home Rate*"
       over: Over
       million: million
     next_steps:

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,8 +1,8 @@
 module MortgageCalculator
   module Version
     MAJOR = 1
-    MINOR = 8
-    PATCH = 1
+    MINOR = 9
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
## Stamp duty calculator, removing mentions of 2016

As we are approaching the 2017 - 2018 tax year we no longer need to mention that changes came into affect 'from April 2016'.  