### PR TITLE
[DEV APPROVED] - 7966 - Mortgage Calculator results page title

### DIFF
--- a/app/views/mortgage_calculator/stamp_duties/_header.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_header.html.erb
@@ -1,1 +1,0 @@
-<h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.h1') %></h1>

--- a/app/views/mortgage_calculator/stamp_duties/_top.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_top.html.erb
@@ -1,2 +1,0 @@
-<h1><%= I18n.t("stamp_duty.title") %></h1>
-<p><%= I18n.t("stamp_duty.subtitle") %></p>

--- a/app/views/mortgage_calculator/stamp_duties/create.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/create.html.erb
@@ -1,4 +1,3 @@
 <div class="stamp-duty">
-  <%= render 'header' %>
   <%= render 'form_step2' %>
 </div>

--- a/app/views/mortgage_calculator/stamp_duties/create.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/create.html.erb
@@ -1,3 +1,4 @@
 <div class="stamp-duty">
+	<h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.heading_results') %></h1>
   <%= render 'form_step2' %>
 </div>

--- a/app/views/mortgage_calculator/stamp_duties/show.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/show.html.erb
@@ -1,17 +1,18 @@
 <div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
-  <%= render 'header' %>
 
   <% @stamp_duty.errors.full_messages.each do |m| %>
     <span style="color:red;"><%= m %></span>
   <% end %> 
-  <h2 class="intro stamp-duty__subheading"><%= I18n.t('stamp_duty.title') %></h2>
   <div wizard on-finish="finishedWizard()" hide-indicators='true'>
     <div wz-step class="ng-hide">
+      <h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.h1') %></h1>
+      <h2 class="intro stamp-duty__subheading"><%= I18n.t('stamp_duty.title') %></h2>
       <%= render 'form_step1' %>
     </div>
 
     <div wz-step class="ng-hide">
       <div class="rendered-from-js">
+        <h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.h1_results') %></h1>
         <%= render 'form_step2' %>
       </div>
     </div>

--- a/app/views/mortgage_calculator/stamp_duties/show.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/show.html.erb
@@ -5,14 +5,14 @@
   <% end %> 
   <div wizard on-finish="finishedWizard()" hide-indicators='true'>
     <div wz-step class="ng-hide">
-      <h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.h1') %></h1>
+      <h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.heading') %></h1>
       <h2 class="intro stamp-duty__subheading"><%= I18n.t('stamp_duty.title') %></h2>
       <%= render 'form_step1' %>
     </div>
 
     <div wz-step class="ng-hide">
       <div class="rendered-from-js">
-        <h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.h1_results') %></h1>
+        <h1 class="stamp-duty__heading"><%= I18n.t('stamp_duty.heading_results') %></h1>
         <%= render 'form_step2' %>
       </div>
     </div>

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -7,6 +7,7 @@ cy:
     tool_name: "cyfrifiannell-treth-stamp"
     pretitle: "Defnyddiwch y gyfrifiannell hon i gyfrifo faint o dreth stamp y bydd angen ichi ei thalu ar gartref newydd"
     h1: "Cyfrifiannell treth stamp"
+    h1_results: Cyfrifiannell treth stamp - Eich canlyniadau
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl"
     second_subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy. Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
     subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000 (£40,000 ar gyfer cartrefi ychwanegol). Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy."

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -6,8 +6,8 @@ cy:
       canonical_url: "https://www.moneyadviceservice.org.uk/cy/tools/prynu-ty/cyfrifiannell-treth-stamp"
     tool_name: "cyfrifiannell-treth-stamp"
     pretitle: "Defnyddiwch y gyfrifiannell hon i gyfrifo faint o dreth stamp y bydd angen ichi ei thalu ar gartref newydd"
-    h1: "Cyfrifiannell treth stamp"
-    h1_results: Cyfrifiannell treth stamp - Eich canlyniadau
+    heading: "Cyfrifiannell treth stamp"
+    heading_results: "Cyfrifiannell treth stamp - Eich canlyniadau"
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl"
     second_subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy. Os ydych yn byw yn yr Alban, mae Treth Stamp wedi ei ddileu ond efallai y bydd angen i chi dalu Treth Trafodion Tir ac Adeiladau (LBTT)."
     subtitle: "Cyfrifwch y Dreth Stamp ar eich eiddo preswyl yng Nghymru, Lloegr neu Ogledd Iwerddon. Rhaid i chi dalu Treth Stamp (neu Dreth Dir y Dreth Stamp i roi ei henw’n llawn) os prynwch eiddo sy’n costio mwy na £125,000 (£40,000 ar gyfer cartrefi ychwanegol). Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd yn daladwy."

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -6,8 +6,8 @@ en:
       canonical_url: "https://www.moneyadviceservice.org.uk/en/tools/house-buying/stamp-duty-calculator"
     tool_name: "stamp-duty-calculator"
     pretitle: Use this calculator to work out much Stamp Duty you’ll need to pay on a new home
-    h1: Stamp Duty calculator
-    h1_results: Stamp Duty Calculator - Your Results
+    heading: "Stamp Duty calculator"
+    heading_results: "Stamp Duty Calculator - Your Results"
     title: Calculate the Stamp Duty on your residential property
     subtitle: "Calculate the Stamp Duty on your residential property in England, Wales or Northern Ireland. You have to pay Stamp Duty (SDLT) if you buy a property costing more than £125,000 (£40,000 for additional homes). Use this calculator to work out how much Stamp Duty is payable."
     subtitle_legislation_change: "Anyone purchasing an additional home including buy to let properties will have to pay an extra 3% surcharge on top of each stamp duty band."

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -7,6 +7,7 @@ en:
     tool_name: "stamp-duty-calculator"
     pretitle: Use this calculator to work out much Stamp Duty you’ll need to pay on a new home
     h1: Stamp Duty calculator
+    h1_results: Stamp Duty Calculator - Your Results
     title: Calculate the Stamp Duty on your residential property
     subtitle: "Calculate the Stamp Duty on your residential property in England, Wales or Northern Ireland. You have to pay Stamp Duty (SDLT) if you buy a property costing more than £125,000 (£40,000 for additional homes). Use this calculator to work out how much Stamp Duty is payable."
     subtitle_legislation_change: "Anyone purchasing an additional home including buy to let properties will have to pay an extra 3% surcharge on top of each stamp duty band."

--- a/features/stamp_duty.feature
+++ b/features/stamp_duty.feature
@@ -12,10 +12,12 @@ Scenario: Welsh users
   Given I visit the Welsh Stamp Duty page
   Then  I see the Welsh stamp duty calculator
 
+@javascript
 Scenario Outline: stamp duty for first home
   Given I visit the Stamp Duty page
   When I enter a house price of <price>
   And I click next
+  Then I see the title for the results page
   Then I see the stamp duty I will have to pay is "£<duty>"
 
 Examples:

--- a/features/step_definitions/stamp_duty.rb
+++ b/features/step_definitions/stamp_duty.rb
@@ -15,7 +15,7 @@ Given(/^I visit the Syndicated Stamp Duty page$/) do
 end
 
 Then /^they should see the Stamp Duty calculator$/ do
-  expect(@stamp_duty).to have_content(I18n.t('stamp_duty.h1'))
+  expect(@stamp_duty).to have_content(I18n.t('stamp_duty.heading'))
 end
 
 Then(/^they do not see the result output$/) do
@@ -32,6 +32,10 @@ end
 
 When(/^I click next$/) do
   @stamp_duty.next.click
+end
+
+Then(/^I see the title for the results page$/) do
+  expect(@stamp_duty.h1.first).to have_content('Stamp Duty Calculator - Your Results')
 end
 
 When(/^I select to calculate for a second home$/) do

--- a/features/step_definitions/stamp_duty.rb
+++ b/features/step_definitions/stamp_duty.rb
@@ -64,5 +64,5 @@ And(/^I see that the stamp duty cost falls into a band of "(.*?)"$/) do |content
 end
 
 Then(/^I see the Welsh stamp duty calculator$/) do
-  expect(@stamp_duty.h1).to have_content('Cyfrifiannell treth stamp')
+  expect(@stamp_duty.h1.first).to have_content('Cyfrifiannell treth stamp')
 end

--- a/features/support/ui/pages/stamp_duty.rb
+++ b/features/support/ui/pages/stamp_duty.rb
@@ -5,7 +5,7 @@ module UI
 
       set_url "/{locale}/mortgage_calculator/stamp-duty-calculator"
 
-      element :h1, "h1"
+      elements :h1, "h1"
       element :h2, "h2"
       element :property_price, "form.step_one input[name='stamp_duty[price]']"
       element :property_price_step_two, "form.step_two input[name='stamp_duty[price]']"

--- a/features/support/ui/pages/stamp_duty.rb
+++ b/features/support/ui/pages/stamp_duty.rb
@@ -15,7 +15,6 @@ module UI
 
       element :results, "p[class='results']"
       element :results_text, "p[class='results-text']"
-
       element :recalculate, "form.step_two input[type=submit]"
     end
 

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 1
     MINOR = 9
-    PATCH = 4
+    PATCH = 5
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,8 +1,8 @@
 module MortgageCalculator
   module Version
     MAJOR = 1
-    MINOR = 9
-    PATCH = 5
+    MINOR = 10
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
## Issue
Page Titles on the Stamp Duty Calculator are not specific to the progress through the tool.

As a user relying on screen reader technology, I need the title of a page to change to inform me that I am on the results page of a tool so that I can easily tell that I have progressed.

## Solution
The way Angular handles page titles makes it complicated to update the page titles within views.
This solution removes the page titles from the angular app and places them in the ruby view. These titles are not relevant to the actual angular app.

Cucumber tests were updated to represent the view changes.

### Note
During testing it was discovered that Cucumber 3.0.1 is not compatible with some of the tests being run on this tool. 

| English | Welsh |
|--------| -------|
| <img width="1163" alt="screen shot 2017-11-01 at 09 49 20" src="https://user-images.githubusercontent.com/2187295/32269675-1e8e6d7a-beeb-11e7-9b1e-bfecd824f046.png">| <img width="1168" alt="screen shot 2017-11-01 at 09 50 00" src="https://user-images.githubusercontent.com/2187295/32269747-2971ce62-beeb-11e7-86dd-2a369a95d27a.png">|