### PR TITLE
[DEV APPROVED] Cucumber test hotfix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'meta-tags'
 group :test do
   gem 'capybara'
   gem 'coffee-rails'
+  gem 'cucumber', '~> 3.0.1'
   gem 'factory_girl_rails'
   gem 'mas-templating'
   gem 'rspec-its'

--- a/features/step_definitions/affordability.rb
+++ b/features/step_definitions/affordability.rb
@@ -190,8 +190,6 @@ Given(/^living costs of (\d+), (\d+) and (\d+)$/) do |ents, hols, food|
 end
 
 When(/^I set the term to (\d+) and interest to (\d+)$/) do |term, rate|
-  return if term == DEFAULT_ANNUAL_TERM_YEARS && rate == DEFAULT_ANNUAL_INTEREST_RATE
-
   step_three.term_years.set term
   step_three.interest_rate.set rate
   step_three.recalculate.click

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 1
     MINOR = 10
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
## Issue
This PR addresses an issue with existing cucumber tests within the affordability calculator. The use of a `return` in a step definition is making tests to fail in version 3.0.1 of cucumber used in the gem.

This issue is preventing deployment of work for this tool.

## Solution
The use of `return` is used to skip the default values of the tests and increase the speed at which it runs. Since the use of this `return` is not essential for the running of the tests. It has been removed. The tests now pass.

