### PR TITLE
[DEV APPROVED]8649 Update Affordability Calculator Step 1

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_affordability.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_affordability.scss
@@ -96,3 +96,15 @@
     }
   }
 }
+
+.affcalc__label {
+  @extend label
+}
+
+.affcalc__sub-label {
+  font-size: 1rem;
+}
+
+.js .popup-tip__container {
+  z-index: 3;
+}

--- a/app/views/mortgage_calculator/affordabilities/_close.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_close.html.erb
@@ -1,0 +1,10 @@
+<button data-dough-popup-close type="button" class="popup-tip__close">
+  <span aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--mobile-close-box">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--mobile-close-box"></use>
+    </svg>
+  </span>
+  <span class="visually-hidden">
+    <%= t('affordability.tooltips.tooltip_close') %>
+  </span>
+</button>

--- a/app/views/mortgage_calculator/affordabilities/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step1.html.erb
@@ -2,12 +2,12 @@
   <% f.validates @affordability, @affordability.people[0], @affordability.people[1] %>
 
   <div class="affcalc__col--clip">
-    <p><strong><%= t("affordability.required_copy") %></strong></p>
+    <p><strong><%= t('affordability.required_copy') %></strong></p>
     <%= f.validation_summary %>
   </div>
 
   <div class="affcalc__col">
-    <h3><%= I18n.t("affordability.titles.annual_income") %></h3>
+    <h3><%= I18n.t('affordability.titles.annual_income') %></h3>
   </div>
 
   <%= f.fields_for :people do |person| %>
@@ -20,7 +20,7 @@
           <%= person.form_row :annual_income do %>
             <%= person.errors_for :annual_income %>
             <%= person.label :annual_income, "id" => "label_annual_income0" do %>
-              <%= t("affordability.activemodel.attributes.mortgage_calculator/person.annual_income")%> * <span class="visually-hidden"><%= t("affordability.per_year") %>, <%= t("affordability.required") %></span>
+              <%= t('affordability.activemodel.attributes.mortgage_calculator/person.annual_income')%> * <span class="visually-hidden"><%= t('affordability.per_year') %>, <%= t('affordability.required') %></span>
             <% end %>
 
             <span class="form__input-container">
@@ -39,28 +39,58 @@
                                       "aria-required" => "true",
                                       "value" => person.object.annual_income_formatted,
                                       "pattern" => '\d*' %>
-              <span class="form__input-label" id="label_annual_income0b"><%= t("affordability.per_year") %></span>
+              <span class="form__input-label" id="label_annual_income0b"><%= t('affordability.per_year') %></span>
               <span class="form__input-outline"></span>
             </span>
           <% end %>
-        </div>
-
-        <div class="affcalc__col--tooltip">
-          <%= field_tooltip text: t("affordability.tooltips.mortgage_calculator/person.annual_income_0_html"),
-                html: {
-                  id: 'tip_annual_income_0'
-                }
-            %>
         </div>
       </div>
 
       <div class="affcalc__row">
         <div class="affcalc__col--field">
+          <%= person.form_row :monthly_net_income do %>
+            <%= person.errors_for :monthly_net_income %>
+            <%= person.label :monthly_net_income, "id" => "label_monthly_net_income_0" do %>
+              <%= t('affordability.activemodel.attributes.mortgage_calculator/person.monthly_net_income')%> * 
+              <span class="affcalc__row affcalc__sub-label"><%= t("affordability.activemodel.attributes.mortgage_calculator/person.monthly_net_sub")%></span>
+              <span class="visually-hidden"><%= t('affordability.per_month') %>, <%= t('affordability.required') %></span>
+            <% end %>
+
+            <span class="form__input-container">
+              <span class="form__input-label" id="label_monthly_net_income_0a">&pound;</span>
+              <%= person.text_field :monthly_net_income,
+                                    "class" => "form-control form__input",
+                                    "ng-model" => "affordability.earnings.person0.net_pay",
+                                    "ng-initial" => "",
+                                    "currency" => '',
+                                    "placeholder" => "0",
+                                    "aria-describedby" => "tip_monthly_net_income_0",
+                                    "aria-labelledby" => "label_monthly_net_income_0 label_monthly_net_income_0a label_monthly_net_income_0b",
+                                    "required" => "required",
+                                    "aria-required" => "true",
+                                    "value" => person.object.monthly_net_income_formatted,
+                                    "pattern" => '\d*' %>
+              <span class="form__input-label" id="label_monthly_net_income_0b"><%= t('affordability.per_month') %></span>
+              <span class="form__input-outline"></span>
+            </span>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="affcalc__row" data-dough-component="PopupTip">
+        <div class="affcalc__col--field">
           <%= person.form_row :extra_income do %>
             <%= person.errors_for :extra_income %>
             <%= person.label :extra_income, "id" => "label_extra_income0" do %>
-              <%= t("affordability.activemodel.attributes.mortgage_calculator/person.extra_income") %>
-              <span class="visually-hidden"><%= t("affordability.per_year") %></span>
+              <%= t('affordability.activemodel.attributes.mortgage_calculator/person.extra_income') %>
+              <%= render 'mortgage_calculator/affordabilities/tooltips/trigger' %>
+              <div data-dough-popup-container class="popup-tip__container details__helper">
+                <p data-dough-popup-content class="popup-tip__content">
+                  <%= t('affordability.tooltips.annual') %>
+                </p>
+                <%= render 'mortgage_calculator/affordabilities/tooltips/close' %>
+              </div>
+              <span class="visually-hidden"><%= t('affordability.per_year') %></span>
             <% end %>
 
             <span class="form__input-container">
@@ -76,26 +106,22 @@
                                     "aria-labelledby" => "label_extra_income0 label_extra_income0a label_extra_income0b",
                                     "value" => person.object.extra_income_formatted,
                                     "pattern" => '\d*' %>
-              <span class="form__input-label" id="label_extra_income0b"><%= t("affordability.per_year") %></span>
+              <span class="form__input-label" id="label_extra_income0b"><%= t('affordability.per_year') %></span>
               <span class="form__input-outline"></span>
             </span>
           <% end %>
-        </div>
-        <div class="affcalc__col--tooltip">
-          <%= field_tooltip text: t("affordability.tooltips.mortgage_calculator/person.extra_income_0_html"),
-              html: {
-                id: 'tip_extra_income_0'
-              }
-          %>
         </div>
       </div>
     <% else %>
 
       <div class="affcalc__row">
         <div class="affcalc__col">
+          <span class="affcalc__label"><%= I18n.t('affordability.titles.second_applicant') %></span>
+          <span class="visually-hidden">(displays new content below)</span>
+
           <%= f.form_row do %>
             <%= f.label :two_applicants,
-                        class: "label--inline label--accent" do %>
+                        class: "label--inline" do %>
               <%= f.check_box :two_applicants,
                               "ng-model" => "affordability.selectedOption",
                               "ng-initial" => @affordability.two_applicants? ? "1" : "0",
@@ -106,7 +132,7 @@
                               "name" => "affordability[two_applicants]",
                               "affects-height" => "change",
                               :checked => @affordability.two_applicants? %>
-              <%= I18n.t("affordability.titles.second_applicant") %> <span class="visually-hidden">(displays new content below)</span>
+              <span class="label--inline"><%= I18n.t('affordability.titles.checkbox_label') %></span>
             <% end %>
           <% end %>
         </div>
@@ -117,7 +143,7 @@
           <%= person.form_row :annual_income do %>
             <%= person.errors_for :annual_income %>
             <%= person.label :annual_income, "id" => "label_annual_income1" do %>
-              <%= t("affordability.activemodel.attributes.mortgage_calculator/person_other.annual_income")%> * <span class="visually-hidden"><%= t("affordability.per_year") %>, <%= t("affordability.required") %></span>
+              <%= t('affordability.activemodel.attributes.mortgage_calculator/person_other.annual_income')%> * <span class="visually-hidden"><%= t('affordability.per_year') %>, <%= t('affordability.required') %></span>
             <% end %>
 
             <span class="form__input-container">
@@ -136,114 +162,21 @@
                                     "aria-required" => "true",
                                     "value" => person.object.annual_income_formatted,
                                     "pattern" => '\d*' %>
-              <span class="form__input-label" id="label_annual_income1b"><%= t("affordability.per_year") %></span>
+              <span class="form__input-label" id="label_annual_income1b"><%= t('affordability.per_year') %></span>
               <span class="form__input-outline"></span>
             </span>
           <% end %>
         </div>
-
-        <div class="affcalc__col--tooltip">
-          <%= field_tooltip text: t("affordability.tooltips.mortgage_calculator/person.annual_income_1"),
-              html: {
-                id: 'tip_annual_income_1'
-              }
-          %>
-        </div>
       </div>
 
-      <div class="affcalc__row" ng-class="{ 'is-hidden' : !isCheckboxSelected('1') }">
-        <div class="affcalc__col--field">
-          <%= person.form_row :extra_income do %>
-            <%= person.errors_for :extra_income %>
-            <%= person.label :extra_income, "id" => "label_extra_income_1" do %>
-              <%= t("affordability.activemodel.attributes.mortgage_calculator/person_other.extra_income")%>
-              <span class="visually-hidden"><%= t("affordability.per_year") %></span>
-            <% end %>
-
-            <span class="form__input-container">
-              <span class="form__input-label" id="label_extra_income_1a">&pound;</span>
-              <%= person.text_field :extra_income,
-                                    "class" => "form-control form__input",
-                                    "ng-model" => "affordability.earnings.person1.extra",
-                                    "ng-initial" => "",
-                                    'ng-disabled' => "!isCheckboxSelected('1')",
-                                    "currency" => '',
-                                    "placeholder" => "0",
-                                    "data-m-dec" =>"0",
-                                    "aria-describedby" => "tip_extra_income_1",
-                                    "aria-labelledby" => "label_extra_income_1 label_extra_income_1a label_extra_income_1b",
-                                    "value" => person.object.extra_income_formatted,
-                                    "pattern" => '\d*' %>
-              <span class="form__input-label" id="label_extra_income_1b"><%= t("affordability.per_year") %></span>
-              <span class="form__input-outline"></span>
-            </span>
-          <% end %>
-        </div>
-
-        <div class="affcalc__col--tooltip">
-          <%= field_tooltip text: t("affordability.tooltips.mortgage_calculator/person.extra_income_1"),
-              html: {
-                id: 'tip_extra_income_1'
-              }
-          %>
-        </div>
-      </div>
-    <% end %>
-  <% end %>
-
-  <div class="affcalc__col">
-    <h3><%= I18n.t("affordability.titles.take_home") %></h3>
-  </div>
-
-  <%= f.fields_for :people do |person| %>
-    <% index = @affordability.people.find_index(person.object) %>
-    <% person.object_name = "affordability[people_attributes][#{index}]" %>
-
-    <%# render the first applicant differently to the additional applicants %>
-    <% if index == 0 %>
-      <div class="affcalc__row">
-        <div class="affcalc__col--field">
-          <%= person.form_row :monthly_net_income do %>
-            <%= person.errors_for :monthly_net_income %>
-            <%= person.label :monthly_net_income, "id" => "label_monthly_net_income_0" do %>
-              <%= t("affordability.activemodel.attributes.mortgage_calculator/person.monthly_net_income")%> * <span class="visually-hidden"><%= t("affordability.per_month") %>, <%= t("affordability.required") %></span>
-            <% end %>
-
-            <span class="form__input-container">
-              <span class="form__input-label" id="label_monthly_net_income_0a">&pound;</span>
-              <%= person.text_field :monthly_net_income,
-                                    "class" => "form-control form__input",
-                                    "ng-model" => "affordability.earnings.person0.net_pay",
-                                    "ng-initial" => "",
-                                    "currency" => '',
-                                    "placeholder" => "0",
-                                    "aria-describedby" => "tip_monthly_net_income_0",
-                                    "aria-labelledby" => "label_monthly_net_income_0 label_monthly_net_income_0a label_monthly_net_income_0b",
-                                    "required" => "required",
-                                    "aria-required" => "true",
-                                    "value" => person.object.monthly_net_income_formatted,
-                                    "pattern" => '\d*' %>
-              <span class="form__input-label" id="label_monthly_net_income_0b"><%= t("affordability.per_month") %></span>
-              <span class="form__input-outline"></span>
-            </span>
-          <% end %>
-        </div>
-
-        <div class="affcalc__col--tooltip">
-          <%= field_tooltip text: t("affordability.tooltips.mortgage_calculator/person.monthly_net_income_0"),
-              html: {
-                id: 'tip_monthly_net_income_0'
-              }
-          %>
-        </div>
-      </div>
-    <% else %>
       <div class="affcalc__row" ng-class="{ 'is-hidden' : !isCheckboxSelected('1') }">
         <div class="affcalc__col--field">
           <%= person.form_row :monthly_net_income do %>
             <%= person.errors_for :monthly_net_income %>
             <%= person.label :monthly_net_income, "id" => "label_monthly_net_income_1" do %>
-              <%= t("affordability.activemodel.attributes.mortgage_calculator/person_other.monthly_net_income")%> * <span class="visually-hidden"><%= t("affordability.per_month") %>, <%= t("affordability.required") %></span>
+              <%= t('affordability.activemodel.attributes.mortgage_calculator/person_other.monthly_net_income')%> *
+              <span class="affcalc__row affcalc__sub-label"><%= t("affordability.activemodel.attributes.mortgage_calculator/person_other.monthly_net_sub_other")%></span>
+              <span class="visually-hidden"><%= t("affordability.per_month") %>, <%= t('affordability.required') %></span>
             <% end %>
 
             <span class="form__input-container">
@@ -261,18 +194,47 @@
                                     "aria-required" => "true",
                                     "value" => person.object.monthly_net_income_formatted,
                                     "pattern" => '\d*' %>
-              <span class="form__input-label" id="label_monthly_net_income_1b"><%= t("affordability.per_month") %></span>
+              <span class="form__input-label" id="label_monthly_net_income_1b"><%= t('affordability.per_month') %></span>
               <span class="form__input-outline"></span>
             </span>
           <% end %>
         </div>
+      </div>
 
-        <div class="affcalc__col--tooltip">
-          <%= field_tooltip text: t("affordability.tooltips.mortgage_calculator/person.monthly_net_income_1"),
-              html: {
-                id: 'tip_monthly_net_income_1'
-              }
-          %>
+      <div class="affcalc__row" ng-class="{ 'is-hidden' : !isCheckboxSelected('1') }" data-dough-component="PopupTip">
+        <div class="affcalc__col--field">
+          <%= person.form_row :extra_income do %>
+            <%= person.errors_for :extra_income %>
+            <%= person.label :extra_income, "id" => "label_extra_income_1" do %>
+              <%= t('affordability.activemodel.attributes.mortgage_calculator/person_other.extra_income')%>
+              <%= render 'mortgage_calculator/affordabilities/tooltips/trigger' %>
+              <div data-dough-popup-container class="popup-tip__container details__helper">
+                <p data-dough-popup-content class="popup-tip__content">
+                  <%= t('affordability.tooltips.annual') %>
+                </p>
+                <%= render 'mortgage_calculator/affordabilities/tooltips/close' %>
+              </div>
+              <span class="visually-hidden"><%= t('affordability.per_year') %></span>
+            <% end %>
+
+            <span class="form__input-container">
+              <span class="form__input-label" id="label_extra_income_1a">&pound;</span>
+              <%= person.text_field :extra_income,
+                                    "class" => "form-control form__input",
+                                    "ng-model" => "affordability.earnings.person1.extra",
+                                    "ng-initial" => "",
+                                    'ng-disabled' => "!isCheckboxSelected('1')",
+                                    "currency" => '',
+                                    "placeholder" => "0",
+                                    "data-m-dec" =>"0",
+                                    "aria-describedby" => "tip_extra_income_1",
+                                    "aria-labelledby" => "label_extra_income_1 label_extra_income_1a label_extra_income_1b",
+                                    "value" => person.object.extra_income_formatted,
+                                    "pattern" => '\d*' %>
+              <span class="form__input-label" id="label_extra_income_1b"><%= t('affordability.per_year') %></span>
+              <span class="form__input-outline"></span>
+            </span>
+          <% end %>
         </div>
       </div>
     <% end %>
@@ -280,7 +242,7 @@
 
   <div class="affcalc__col">
     <%= f.form_row do %>
-      <%= f.submit I18n.t("affordability.next"),
+      <%= f.submit I18n.t('affordability.next'),
              class: "button button--primary mortgagecalc__submit mortgagecalc__submit--flow" %>
     <% end %>
   </div>

--- a/app/views/mortgage_calculator/affordabilities/tooltips/_close.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/tooltips/_close.html.erb
@@ -1,0 +1,10 @@
+<button data-dough-popup-close type="button" class="popup-tip__close">
+  <span aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--mobile-close-box">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--mobile-close-box"></use>
+    </svg>
+  </span>
+  <span class="visually-hidden">
+    <%= t('wpcc.tooltip_hide') %>
+  </span>
+</button>

--- a/app/views/mortgage_calculator/affordabilities/tooltips/_trigger.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/tooltips/_trigger.html.erb
@@ -1,0 +1,4 @@
+<button type="button" class="popup-tip__button" data-dough-popup-trigger>
+  <span aria-hidden="true">i</span>
+  <span class="visually-hidden"><%= t('affordability.tooltips.tooltip_show') %></span>
+</button>

--- a/config/locales/affordability.cy.yml
+++ b/config/locales/affordability.cy.yml
@@ -42,15 +42,17 @@ cy:
         mortgage_calculator/person:
           raw_annual_income: "Eich incwm blynyddol"
           raw_monthly_net_income: "Eich cyflog clir misol"
-          annual_income: "Eich incwm blynyddol"
-          extra_income: "Unrhyw incwm blynyddol arall"
-          monthly_net_income: "Eich cyflog clir misol"
+          annual_income: "Beth yw eich incwm neu gyflog blynyddol cyn talu treth?"
+          extra_income: "A oes gennych chi unrhyw incwm arall? (Dewisol)"
+          monthly_net_income: "Beth yw eich cyflog clir misol?"
+          monthly_net_sub: "(dyma yw eich incwm misol ar ôl treth, meinws pensiwn, Yswiriant Gwladol, a didyniadau eraill)"
         mortgage_calculator/person_other:
           raw_annual_income: "Incwm blynyddol ail ymgeisydd"
           raw_monthly_net_income: "Cyflog clir misol ail ymgeisydd"
-          annual_income: "Incwm blynyddol ail ymgeisydd"
-          extra_income: "Incwm blynyddol arall ail ymgeisydd"
-          monthly_net_income: "Cyflog clir misol ail ymgeisydd"
+          annual_income: "Beth yw incwm neu gyflog blynyddol yr ail ymgeisydd cyn tynnu treth?"
+          extra_income: "A oes gan yr ail ymgeisydd unrhyw incwm arall? (Dewisol)"
+          monthly_net_income: "Beth yw cyflog yr ail ymgeisydd ar ôl tynnu treth?"
+          monthly_net_sub_other: "(dyma yw ei incwm misol ar ôl treth, meinws pensiwn, Yswiriant Gwladol, a didyniadau eraill)"
       errors:
         title: "Gwiriwch y ffurflen a chywiro’r gwallau canlynol"
         messages:
@@ -80,6 +82,9 @@ cy:
           base:
             proportional_incomes: "Mae cyflog clir misol yr ail ymgeisydd yn uwch na’i incwm blynyddol."
     tooltips:
+      tooltip_show: sioe help
+      tooltip_hide: cuddio cymorth
+      annual: "ylid cynnwys incwm o swyddi eraill, incwm pensiwn, bonws wedi ei warantu, goramser rheolaidd, cyflogaeth arall, incwm rhent, taliadau cynhaliaeth, pensiwn, lwfans car ac ati"
       mortgage_calculator/outgoings:
         credit_repayments_html: "<b>Dylid cynnwys:</b> dyledion cerdyn credyd, cerdyn siop a chatalog; benthyciadau car a phersonol, benthyciadau myfyrwyr; ac ymroddiadau hurbwrcasu<br /><b>Ni ddylid cynnwys</b>: Costau byw o ddydd i ddydd (e.e. bwyd, dillad, adloniant a gwyliau); gwariant sefydlog (e.e. tanysgrifiadau i gampfeydd neu daliadau aelodaeth eraill; biliau gwasanaethau; ffonau symudol; band eang; y dreth gyngor; ffioedd gofal plant neu ysgol)"
         utilities_html: "<b>Dylid cynnwys:</b> Y Dreth Gyngor, aelodaeth o gampfa, biliau gwasanaethau; ffonau symudol; yswiriant blynyddol (megis cynnwys, car, anifeiliaid anwes, teithio), tanysgrifiadau cylchgronau, band eang, adferiad ochr y ffordd ac ati"
@@ -113,6 +118,7 @@ cy:
       how_affect_budget: "Allwch chi fforddio'r taliadau misol?"
       can_afford: "Beth sy’n weddill?"
       second_applicant: "A oes ail ymgeisydd?"
+      checkbox_label: ie
     input_page:
       submit: "Gwiriwch faint allwch chi ei fenthyg"
       monthly_outgoings_descriptions_html: "Defnyddiwch yr adran hon i gael syniad sylfaenol o sut mae’ch cyllideb fisol yn cael ei chyfrifo, a pa mor fforddiadwy fydd eich taliadau morgais misol."

--- a/config/locales/affordability.en.yml
+++ b/config/locales/affordability.en.yml
@@ -42,15 +42,17 @@ en:
         mortgage_calculator/person:
           raw_annual_income: "Your annual income"
           raw_monthly_net_income: "Your monthly take-home pay"
-          annual_income: "Your annual income"
-          extra_income: "Any other annual income"
-          monthly_net_income: "Your monthly take-home pay"
+          annual_income: "What is your annual income or salary before tax?"
+          extra_income: "Do you have any other income? (Optional)"
+          monthly_net_income: "What is your monthly take-home pay?"
+          monthly_net_sub: "(this is your monthly income after tax, minus pension, NI and other deductions)"
         mortgage_calculator/person_other:
           raw_annual_income: "Second applicant's annual income"
           raw_monthly_net_income: "Second applicant's monthly take-home pay"
-          annual_income: "Second applicant's annual income"
-          extra_income: "Second applicant's other annual income"
-          monthly_net_income: "Second applicant's monthly take-home pay"
+          annual_income: "What is the second applicant's annual income or salary before tax?"
+          extra_income: "Does the second applicant have any other income? (Optional)"
+          monthly_net_income: "What is the second applicant's monthly take-home pay?"
+          monthly_net_sub_other: "(This is their monthly income after tax, minus pension, NI and other deductions)"
       errors:
         title: "Please check the form and correct the following errors"
         messages:
@@ -80,6 +82,9 @@ en:
           base:
             proportional_incomes: "Second applicant's monthly take-home pay is higher than their annual income."
     tooltips:
+      tooltip_show: show help
+      tooltip_hide: hide help
+      annual: "Include income from other jobs, pension income, guaranteed bonus, regular overtime, other employment, rental income, maintenance payments, pension, car allowance etc"
       mortgage_calculator/outgoings:
         credit_repayments_html: "<b>Include:</b> credit card, store card and catalogue debts; car finance and personal loans; student loans; and hire purchase commitments<br><b>Exclude</b>: Day-to-day living costs (e.g. food, clothes, entertainment and holidays); fixed spending (e.g. subscriptions to gyms or other memberships; utility bills; mobile phones; broadband; council tax; childcare or school fees)"
         utilities_html: "<b>Include:</b> Council Tax, gym memberships, utility bills, mobile phones, annual insurance (such as contents, car, pet, travel),  magazine subscriptions, broadband, roadside recovery etc"
@@ -113,6 +118,7 @@ en:
       how_affect_budget: "Can you afford these monthly payments?"
       can_afford: "What's left over?"
       second_applicant: "Is there a second applicant?"
+      checkbox_label: "yes"
     input_page:
       submit: "Find out how much you can borrow"
       monthly_outgoings_descriptions_html: "Use this section to get a basic idea of how your monthly budget adds up, and how affordable your monthly mortgage payments will be."

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,8 +1,8 @@
 module MortgageCalculator
   module Version
     MAJOR = 1
-    MINOR = 10
-    PATCH = 2
+    MINOR = 11
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
## This PR addresses the following tickets: 
[8649](https://moneyadviceservice.tpondemand.com/entity/8649) Reordering input fields 
[8651](https://moneyadviceservice.tpondemand.com/entity/8651) Wording change  
[8652](https://moneyadviceservice.tpondemand.com/entity/8652) Add tooltip (remove existing tooltips) 

### 8649
Reordered input fields.

### 8651
Updated copy for input labels and tooltips

### 8652
Removed the on focus helper text from associated input fields.
Added an on-click, informational tooltip i  for the optional input field about "any other income".

|English| Welsh|
|-------|-------|
| ![english](https://user-images.githubusercontent.com/2187295/33080442-02378248-ced0-11e7-8364-b3f4c49b0d7b.png) | ![welsh](https://user-images.githubusercontent.com/2187295/33080454-0d0bd188-ced0-11e7-82bc-6b4065bb2397.png)|