### PR TITLE
8698 stamp duty update

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_global-alert.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_global-alert.scss
@@ -1,0 +1,8 @@
+.global-alert {
+  top: 0;
+  margin-top: $baseline-unit*2;
+}
+
+.global-alert__list {
+  font-size: 0.9em;
+}

--- a/app/views/mortgage_calculator/stamp_duties/_budget_warning.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_budget_warning.html.erb
@@ -1,0 +1,12 @@
+<div class="global-alert global-alert--warning">
+  <div class="global-alert__content-container">
+    <strong class="global-alert__heading">
+      <%= t('mortgage_calculator.budget_warning.heading') %>
+    </strong>
+      <p class="global-alert__message"><%= t('mortgage_calculator.budget_warning.intro') %></p>
+      <ul class="global-alert__list">
+        <%= t('mortgage_calculator.budget_warning.list_html') %>
+      </ul>
+      <p class="global-alert__message"><%= t('mortgage_calculator.budget_warning.outro') %></p>
+  </div>
+</div>

--- a/app/views/mortgage_calculator/stamp_duties/show.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/show.html.erb
@@ -1,5 +1,6 @@
-<div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
+<%= render 'budget_warning' %>
 
+<div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
   <% @stamp_duty.errors.full_messages.each do |m| %>
     <span style="color:red;"><%= m %></span>
   <% end %> 

--- a/config/locales/mortgage_calculator.cy.yml
+++ b/config/locales/mortgage_calculator.cy.yml
@@ -5,6 +5,14 @@ cy:
       description: "Defnyddiwch ein Cyfrifiannell Morgais i ganfod faint fydd eich taliadau morgais misol yn cynnwys yr ad-daliad a'r taliad llog."
       canonical_url: "https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-morgais"
     tool_name: "cyfrifiannell-morgais-newydd"
+    budget_warning:
+      heading: "Sylwer:"
+      intro: "Yn dilyn cyhoeddiad y Gyllideb ar 22 Tachwedd Os ydych yn brynwr tro cyntaf:"
+      outro: "Mae’r newid hwn yn berthnasol i brynwyr yng Nghymru, Lloegr a Gogledd Iwerddon. Byddwn yn diweddaru’r offeryn i adlewyrchu’r polisi newydd ar y Dreth Stamp dros y dyddiau nesaf."
+      list_html: |
+        <li>Ni fyddwch yn talu Treth Stamp mwyach ar y £300,000 cyntaf wrth brynu eiddo sy’n werth hyd at £500,000.</li>
+        <li>Rhwng £300,000 a £500,000 bydd y gyfradd safonol o 5% yn berthnasol.</li>
+        <li>Os yw pris prynu’ch eiddo dros £500,000 ni fydd yr eithriad hwn yn berthnasol a byddwch yn talu’r cyfraddau safonol o’r Dreth Stamp.</li>
     activemodel:
       attributes:
         mortgage_calculator/repayment:

--- a/config/locales/mortgage_calulator.en.yml
+++ b/config/locales/mortgage_calulator.en.yml
@@ -5,6 +5,14 @@ en:
       description: "Use our Mortgage Calculator to find out your monthly mortgage payments including the repayment and interest payment."
       canonical_url: "https://www.moneyadviceservice.org.uk/en/tools/mortgage-calculator"
     tool_name: "mortgage-calculator-new"
+    budget_warning:
+      heading: "Please Note:"
+      intro: "Following the Budget announcement on 22nd November If you’re a first-time buyer:"
+      outro: "This change applies to buyers in England, Wales and Northern Ireland. We will be updating the tool to reflect the new policy on Stamp Duty in the coming days."
+      list_html: |
+        <li>You will no longer pay Stamp Duty on the first £300,000 on property purchases valued up to £500,000.</li>
+        <li>Between £300,000 and £500, 000 the standard rate of 5% will apply.</li>
+        <li>If your property purchase is over £500,000 this exemption will not apply and you will pay the standard rates of Stamp Duty.</li>
     activemodel:
       attributes:
         mortgage_calculator/repayment:

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 1
     MINOR = 10
-    PATCH = 1
+    PATCH = 2
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
# 8698 stamp duty update

[TP link](https://moneyadviceservice.tpondemand.com/entity/8698)

We need the standard warning message (used in beta and previous tax year end warnings) to appear at the top of the Stamp Duty Calculator. This needs to appear as the changes come into effect today
 
**It should read:**
 
Please Note:

Following the Budget announcement on 22nd November If you’re a first-time buyer:

·         you will no longer pay Stamp Duty on the first £300,000 on property purchases valued up to £500,000.

·         Between £300,000 and £500, 000 the standard rate of 5% will apply.

·         If your property purchase is over £500,000 this exemption will not apply and you will pay the standard rates of Stamp Duty.

This change applies to buyers in England, Wales and Northern Ireland.

We will be updating the tool to reflect the new policy on Stamp Duty in the coming days.
 
![image](https://user-images.githubusercontent.com/13165846/33133536-0755e1c8-cf95-11e7-9d7e-73f5bc7ed683.png)
