### PR TITLE
Updates validation messages and spec model

### DIFF
--- a/config/locales/affordability.cy.yml
+++ b/config/locales/affordability.cy.yml
@@ -62,7 +62,7 @@ cy:
           confirmation: "Nid yw %{attribute} yn cyd-fynd â’r cadarnhad"
           accepted: "Rhaid derbyn %{attribute}"
           empty: "Ni all %{attribute} fod yn wag"
-          blank: "Ni all %{attribute} fod yn wag"
+          blank: 'Nid ydych wedi nodi unrhyw fanylion ar gyfer "%{attribute}"'
           too_long: "Mae %{attribute} yn rhy hir (uchafswm yw %{count} o nodau)"
           too_short: "Mae %{attribute} yn rhy fyr (isafswm yw %{count} o nodau)"
           wrong_length: "Mae hyd %{attribute} yn anghywir (dylai fod yn %{count} o nodau)"

--- a/config/locales/affordability.en.yml
+++ b/config/locales/affordability.en.yml
@@ -62,7 +62,7 @@ en:
           confirmation: "%{attribute} doesn't match confirmation"
           accepted: "%{attribute} must be accepted"
           empty: "%{attribute} can't be empty"
-          blank: "Please enter %{attribute}"
+          blank: 'You have not entered any details for "%{attribute}"'
           too_long: "%{attribute} is too long (maximum is %{count} characters)"
           too_short: "%{attribute} is too short (minimum is %{count} characters)"
           wrong_length: "%{attribute} is the wrong length (should be %{count} characters)"

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 1
     MINOR = 11
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -78,7 +78,7 @@ describe MortgageCalculator::Person do
         end
 
         it 'adds validation for required fields' do
-          expect(subject.errors.messages.values.flatten).to include("Please enter your monthly take-home pay")
+          expect(subject.errors.messages.values.flatten).to include("You have not entered any details for \"what is your monthly take-home pay?\"")
         end
       end
 


### PR DESCRIPTION
## Affordability calculator
This PR adresses rspec testing issue introduced in https://github.com/moneyadviceservice/mortgage_calculator/pull/293

It also updates the validation messages that appear when a user leaves the step 1 questions blank.