### PR TITLE
8709 - Updates how this is calculated section on results

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
@@ -40,9 +40,14 @@ App.factory('StampDuty', function() {
         var totalTax = 0,
             remaining = this.propertyPrice,
             rates,
-            $conditionalMessage = $('.stamp-duty__FTB_conditional');
+            $conditionalMessage = $('.stamp-duty__FTB_conditional'),
+            $howcalculatedFTB = $('.stamp-duty__explanation-firsttimebuyer'),
+            $howcalculatedNextHome = $('.stamp-duty__explanation-nexthome');
 
         if (this.buyerType === 'isFTB') {
+          $howcalculatedNextHome.removeClass('is-active');
+          $howcalculatedFTB.addClass('is-active');
+
           if (this.propertyPrice <= FIRST_TIME_BUYER_THRESHOLD) {
             rates = this.rates_FTB;
             $conditionalMessage.removeClass('is-active');
@@ -53,6 +58,8 @@ App.factory('StampDuty', function() {
         } else {
           rates = this.rates_no_FTB;
           $conditionalMessage.removeClass('is-active');
+          $howcalculatedFTB.removeClass('is-active');
+          $howcalculatedNextHome.addClass('is-active');
         }
 
         for (var i = 0; i < rates.length; i++) {

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -33,6 +33,10 @@
   margin-top: $baseline-unit*2;
 }
 
+.stamp-duty__calculation-explanation-list {
+  @include body(16, 24);
+}
+
 .stamp-duty__heading {
   @include body(24,36);
   margin-top: $baseline-unit*4;

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -28,6 +28,15 @@
   }
 }
 
+.stamp-duty__explanation-firsttimebuyer,
+.stamp-duty__explanation-nexthome {
+  display: none;
+
+  &.is-active {
+    display: block;
+  }
+}
+
 .stamp-duty__calculation-explanation {
   background-color: white;
   margin-top: $baseline-unit*2;

--- a/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
@@ -1,5 +1,49 @@
 <p><%= I18n.t("stamp_duty.how_calculated") %></p>
-<p><%= I18n.t("stamp_duty.how_calculated_additional") %></p>
+<p><%= I18n.t("stamp_duty.how_calculated_2") %></p>
+
+<ul class="list stamp-duty__calculation-explanation-list">
+  <% I18n.t("stamp_duty.how_calculated_ftb_list").each do |ftb_list| %>
+    <li><%= ftb_list %></li>
+  <% end %>
+</ul>
+
+<p><%= I18n.t("stamp_duty.how_calculated_3") %></p>
+<p><%= I18n.t("stamp_duty.how_calculated_4") %></p>
+
+<table class="mortgagecalc__table stamp-duty__table">
+  <thead>
+    <tr>
+      <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
+      <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="mortgagecalc__table__price">&pound;0 - &pound;300,000</td>
+      <td class="mortgagecalc__table__rate">0%</td>
+    </tr>
+    <tr>
+      <td class="mortgagecalc__table__price">&pound;300,001 - &pound;500,000</td>
+      <td class="mortgagecalc__table__rate">5%</td>
+    </tr>
+    <tr>
+      <td class="mortgagecalc__table__price">&pound;500,000+</td>
+      <td class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.standard_rates_apply") %></td>
+    </tr>
+  </tbody>
+</table>
+
+<p><%= I18n.t("stamp_duty.how_calculated_5") %></p>
+
+<ul class="list stamp-duty__calculation-explanation-list">
+  <% I18n.t("stamp_duty.how_calculated_default_list").each do |default_list| %>
+    <li><%= default_list %></li>
+  <% end %>
+</ul>
+
+<p><%= I18n.t("stamp_duty.how_calculated_6") %></p>
+<p><%= I18n.t("stamp_duty.how_calculated_7") %></p>
+
 <table class="mortgagecalc__table stamp-duty__table">
   <thead>
     <tr>

--- a/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
@@ -1,16 +1,13 @@
 <div class="stamp-duty__explanation-firsttimebuyer">
-  <p><%= I18n.t("stamp_duty.how_calculated") %></p>
-  <p><%= I18n.t("stamp_duty.how_calculated_2") %></p>
-
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_2") %></p>
   <ul class="list stamp-duty__calculation-explanation-list">
     <% I18n.t("stamp_duty.how_calculated_ftb_list").each do |ftb_list| %>
       <li><%= ftb_list %></li>
     <% end %>
   </ul>
-
-  <p><%= I18n.t("stamp_duty.how_calculated_3") %></p>
-  <p><%= I18n.t("stamp_duty.how_calculated_4") %></p>
-
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_3") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_4") %></p>
   <table class="mortgagecalc__table stamp-duty__table">
     <thead>
       <tr>
@@ -33,20 +30,56 @@
       </tr>
     </tbody>
   </table>
-</div>
-
-<div class="stamp-duty__explanation-nexthome">
-  <p><%= I18n.t("stamp_duty.how_calculated_5") %></p>
-
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_5") %></p>
   <ul class="list stamp-duty__calculation-explanation-list">
-    <% I18n.t("stamp_duty.how_calculated_default_list").each do |default_list| %>
+    <% I18n.t("stamp_duty.how_calculated_ftb_default_list").each do |default_list| %>
       <li><%= default_list %></li>
     <% end %>
   </ul>
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_6") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_7") %></p>
+  <table class="mortgagecalc__table stamp-duty__table">
+    <thead>
+      <tr>
+        <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
+        <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
+        <th class="mortgagecalc__table__extra"><%= I18n.t("stamp_duty.table.extra_rate_header") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;0 - &pound;125,000</td>
+        <td class="mortgagecalc__table__rate">0%</td>
+        <td class="mortgagecalc__table__extra">3%</td>
+      </tr>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;125,001 - &pound;250,000</td>
+        <td class="mortgagecalc__table__rate">2%</td>
+        <td class="mortgagecalc__table__extra">5%</td>
+      </tr>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;250,001 - &pound;925,000</td>
+        <td class="mortgagecalc__table__rate">5%</td>
+        <td class="mortgagecalc__table__extra">8%</td>
+      </tr>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;925,001 - &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
+        <td class="mortgagecalc__table__rate">10%</td>
+        <td class="mortgagecalc__table__extra">13%</td>
+      </tr>
+      <tr>
+        <td class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.over") %> &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
+        <td class="mortgagecalc__table__rate">12%</td>
+        <td class="mortgagecalc__table__extra">15%</td>
+      </tr>
+    </tbody>
+  </table>
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_extra") %></p>
+</div>
 
-  <p><%= I18n.t("stamp_duty.how_calculated_6") %></p>
-  <p><%= I18n.t("stamp_duty.how_calculated_7") %></p>
-
+<div class="stamp-duty__explanation-nexthome">
+  <p><%= I18n.t("stamp_duty.how_calculated") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_additional") %></p>
   <table class="mortgagecalc__table stamp-duty__table">
     <thead>
       <tr>
@@ -88,7 +121,6 @@
       </tr>
     </tbody>
   </table>
-
 
   <p><%= I18n.t("stamp_duty.how_calculated_extra") %></p>
 </div>

--- a/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_bands_table.html.erb
@@ -1,90 +1,94 @@
-<p><%= I18n.t("stamp_duty.how_calculated") %></p>
-<p><%= I18n.t("stamp_duty.how_calculated_2") %></p>
+<div class="stamp-duty__explanation-firsttimebuyer">
+  <p><%= I18n.t("stamp_duty.how_calculated") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_2") %></p>
 
-<ul class="list stamp-duty__calculation-explanation-list">
-  <% I18n.t("stamp_duty.how_calculated_ftb_list").each do |ftb_list| %>
-    <li><%= ftb_list %></li>
-  <% end %>
-</ul>
+  <ul class="list stamp-duty__calculation-explanation-list">
+    <% I18n.t("stamp_duty.how_calculated_ftb_list").each do |ftb_list| %>
+      <li><%= ftb_list %></li>
+    <% end %>
+  </ul>
 
-<p><%= I18n.t("stamp_duty.how_calculated_3") %></p>
-<p><%= I18n.t("stamp_duty.how_calculated_4") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_3") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_4") %></p>
 
-<table class="mortgagecalc__table stamp-duty__table">
-  <thead>
-    <tr>
-      <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
-      <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="mortgagecalc__table__price">&pound;0 - &pound;300,000</td>
-      <td class="mortgagecalc__table__rate">0%</td>
-    </tr>
-    <tr>
-      <td class="mortgagecalc__table__price">&pound;300,001 - &pound;500,000</td>
-      <td class="mortgagecalc__table__rate">5%</td>
-    </tr>
-    <tr>
-      <td class="mortgagecalc__table__price">&pound;500,000+</td>
-      <td class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.standard_rates_apply") %></td>
-    </tr>
-  </tbody>
-</table>
+  <table class="mortgagecalc__table stamp-duty__table">
+    <thead>
+      <tr>
+        <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
+        <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;0 - &pound;300,000</td>
+        <td class="mortgagecalc__table__rate">0%</td>
+      </tr>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;300,001 - &pound;500,000</td>
+        <td class="mortgagecalc__table__rate">5%</td>
+      </tr>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;500,000+</td>
+        <td class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.standard_rates_apply") %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
-<p><%= I18n.t("stamp_duty.how_calculated_5") %></p>
+<div class="stamp-duty__explanation-nexthome">
+  <p><%= I18n.t("stamp_duty.how_calculated_5") %></p>
 
-<ul class="list stamp-duty__calculation-explanation-list">
-  <% I18n.t("stamp_duty.how_calculated_default_list").each do |default_list| %>
-    <li><%= default_list %></li>
-  <% end %>
-</ul>
+  <ul class="list stamp-duty__calculation-explanation-list">
+    <% I18n.t("stamp_duty.how_calculated_default_list").each do |default_list| %>
+      <li><%= default_list %></li>
+    <% end %>
+  </ul>
 
-<p><%= I18n.t("stamp_duty.how_calculated_6") %></p>
-<p><%= I18n.t("stamp_duty.how_calculated_7") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_6") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_7") %></p>
 
-<table class="mortgagecalc__table stamp-duty__table">
-  <thead>
-    <tr>
-      <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
-      <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
-      <th class="mortgagecalc__table__extra"><%= I18n.t("stamp_duty.table.extra_rate_header") %></th>
-    </tr>
-  </thead>
+  <table class="mortgagecalc__table stamp-duty__table">
+    <thead>
+      <tr>
+        <th class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.property_price_header") %></th>
+        <th class="mortgagecalc__table__rate"><%= I18n.t("stamp_duty.table.rate_header") %></th>
+        <th class="mortgagecalc__table__extra"><%= I18n.t("stamp_duty.table.extra_rate_header") %></th>
+      </tr>
+    </thead>
 
-  <tbody>
-    <tr>
-      <td class="mortgagecalc__table__price">&pound;0 - &pound;125,000</td>
-      <td class="mortgagecalc__table__rate">0%</td>
-      <td class="mortgagecalc__table__extra">3%</td>
-    </tr>
+    <tbody>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;0 - &pound;125,000</td>
+        <td class="mortgagecalc__table__rate">0%</td>
+        <td class="mortgagecalc__table__extra">3%</td>
+      </tr>
 
-    <tr>
-      <td class="mortgagecalc__table__price">&pound;125,001 - &pound;250,000</td>
-      <td class="mortgagecalc__table__rate">2%</td>
-      <td class="mortgagecalc__table__extra">5%</td>
-    </tr>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;125,001 - &pound;250,000</td>
+        <td class="mortgagecalc__table__rate">2%</td>
+        <td class="mortgagecalc__table__extra">5%</td>
+      </tr>
 
-    <tr>
-      <td class="mortgagecalc__table__price">&pound;250,001 - &pound;925,000</td>
-      <td class="mortgagecalc__table__rate">5%</td>
-      <td class="mortgagecalc__table__extra">8%</td>
-    </tr>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;250,001 - &pound;925,000</td>
+        <td class="mortgagecalc__table__rate">5%</td>
+        <td class="mortgagecalc__table__extra">8%</td>
+      </tr>
 
-    <tr>
-      <td class="mortgagecalc__table__price">&pound;925,001 - &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
-      <td class="mortgagecalc__table__rate">10%</td>
-      <td class="mortgagecalc__table__extra">13%</td>
-    </tr>
+      <tr>
+        <td class="mortgagecalc__table__price">&pound;925,001 - &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
+        <td class="mortgagecalc__table__rate">10%</td>
+        <td class="mortgagecalc__table__extra">13%</td>
+      </tr>
 
-    <tr>
-      <td class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.over") %> &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
-      <td class="mortgagecalc__table__rate">12%</td>
-      <td class="mortgagecalc__table__extra">15%</td>
-    </tr>
-  </tbody>
-</table>
+      <tr>
+        <td class="mortgagecalc__table__price"><%= I18n.t("stamp_duty.table.over") %> &pound;1.5 <%= I18n.t("stamp_duty.table.million") %></td>
+        <td class="mortgagecalc__table__rate">12%</td>
+        <td class="mortgagecalc__table__extra">15%</td>
+      </tr>
+    </tbody>
+  </table>
 
 
-<p><%= I18n.t("stamp_duty.how_calculated_extra") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_extra") %></p>
+</div>

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -25,8 +25,20 @@ cy:
       option_isSecondHome: prynu eiddo atodol neu eiddo prynu-i-osod
     recalculate: Ailgyfrifo
     how_calculated_toggle: "Sut y cyfrifir hyn?"
-    how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n prynu eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp gan roi cyfradd dreth effeithiol o 1%."
-    how_calculated_additional: "Bydd unrhyw un sy'n prynu ail gartref, gan gynnwys eiddo prynu i osod, yn talu 3% ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny'n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750, gan roi cyfradd dreth effeithiol o 4%."
+    how_calculated: "Mae prynwyr tro cyntaf yn gymwys i gael gostyngiad Treth Stamp ar y £300,000 cyntaf ar eiddo sy'n werth hyd at £500,000."
+    how_calculated_2: "Er enghraifft, os ydych chi'n prynu eich eiddo cyntaf am £350,000 byddech yn talu:"
+    how_calculated_ftb_list:
+      - "dim Treth Stamp ar werth yr eiddo hyd at £300,000"
+      - "5% o dreth ar y gwerth rhwng £300,001 a £350,000."
+    how_calculated_3: "Yn yr achos hwn, byddai cyfanswm y Dreth Stamp yn £2,500, gan roi cyfradd effeithiol o 0.7%."
+    how_calculated_4: "Ar gyfer eiddo wedi eu prisio dros £500,000, nid oes gostyngiad ar gael a byddech yn talu Treth Stamp ar y pris prynu llawn."
+    how_calculated_5: "Os ydych chi'n prynu eich cartref nesaf neu'n prynu eiddo wedi ei brisio dros £500,000, byddech yn talu:"
+    how_calculated_default_list:
+      - "dim treth ar werth yr eiddo hyd at £125,000"
+      - "2% o dreth ar werth yr eiddo rhwng £125,001 a £250,000"
+      - "5% o dreth ar werth yr eiddo rhwng £250,001 a £550,000."
+    how_calculated_6: "Yn yr achos hwn, byddai cyfanswm y Dreth Stamp yn £17,500, gan roi cyfradd treth effeithiol o 3.2%."
+    how_calculated_7: "Mae'r cyfraddau hyn yn gymwys i Gymru, Lloegr a Gogledd Iwerddon ar hyn o bryd."
     how_calculated_extra: "*Nid yw eiddo dan £40,000 yn destun SDLT ail gartref"
     describe_price_field: Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn.
     activemodel:
@@ -48,6 +60,7 @@ cy:
       property_price_header: "Pris Prynu"
       rate_header: "Cyfradd treth stamp"
       extra_rate_header: "Cyfradd Prynu i Werthu neu Gartref Ychwanegol *"
+      standard_rates_apply: "Codir cyfraddau safonol (gweler isod)"
       over: Dros
       million: miliwn
     next_steps:

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -25,20 +25,23 @@ cy:
       option_isSecondHome: prynu eiddo atodol neu eiddo prynu-i-osod
     recalculate: Ailgyfrifo
     how_calculated_toggle: "Sut y cyfrifir hyn?"
-    how_calculated: "Mae prynwyr tro cyntaf yn gymwys i gael gostyngiad Treth Stamp ar y £300,000 cyntaf ar eiddo sy'n werth hyd at £500,000."
-    how_calculated_2: "Er enghraifft, os ydych chi'n prynu eich eiddo cyntaf am £350,000 byddech yn talu:"
+    how_calculated_ftb: "Mae prynwyr tro cyntaf yn gymwys i gael gostyngiad Treth Stamp ar y £300,000 cyntaf ar eiddo sy'n werth hyd at £500,000."
+    how_calculated_ftb_2: "Er enghraifft, os ydych chi'n prynu eich eiddo cyntaf am £350,000 byddech yn talu:"
     how_calculated_ftb_list:
       - "dim Treth Stamp ar werth yr eiddo hyd at £300,000"
       - "5% o dreth ar y gwerth rhwng £300,001 a £350,000."
-    how_calculated_3: "Yn yr achos hwn, byddai cyfanswm y Dreth Stamp yn £2,500, gan roi cyfradd effeithiol o 0.7%."
-    how_calculated_4: "Ar gyfer eiddo wedi eu prisio dros £500,000, nid oes gostyngiad ar gael a byddech yn talu Treth Stamp ar y pris prynu llawn."
-    how_calculated_5: "Os ydych chi'n prynu eich cartref nesaf neu'n prynu eiddo wedi ei brisio dros £500,000, byddech yn talu:"
-    how_calculated_default_list:
+    how_calculated_ftb_3: "Yn yr achos hwn, byddai cyfanswm y Dreth Stamp yn £2,500, gan roi cyfradd effeithiol o 0.7%."
+    how_calculated_ftb_4: "Ar gyfer eiddo wedi eu prisio dros £500,000, nid oes gostyngiad ar gael a byddech yn talu Treth Stamp ar y pris prynu llawn."
+    how_calculated_ftb_5: "Os ydych chi'n prynu eich cartref nesaf neu'n prynu eiddo wedi ei brisio dros £500,000, byddech yn talu:"
+    how_calculated_ftb_default_list:
       - "dim treth ar werth yr eiddo hyd at £125,000"
       - "2% o dreth ar werth yr eiddo rhwng £125,001 a £250,000"
       - "5% o dreth ar werth yr eiddo rhwng £250,001 a £550,000."
-    how_calculated_6: "Yn yr achos hwn, byddai cyfanswm y Dreth Stamp yn £17,500, gan roi cyfradd treth effeithiol o 3.2%."
-    how_calculated_7: "Mae'r cyfraddau hyn yn gymwys i Gymru, Lloegr a Gogledd Iwerddon ar hyn o bryd."
+    how_calculated_ftb_6: "Yn yr achos hwn, byddai cyfanswm y Dreth Stamp yn £17,500, gan roi cyfradd treth effeithiol o 3.2%."
+    how_calculated_ftb_7: "Mae'r cyfraddau hyn yn gymwys i Gymru, Lloegr a Gogledd Iwerddon ar hyn o bryd."
+    how_calculated_ftb_extra: "*Nid yw eiddo dan £40,000 yn destun SDLT ail gartref"
+    how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n prynu eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp gan roi cyfradd dreth effeithiol o 1%."
+    how_calculated_additional: "Bydd unrhyw un sy'n prynu ail gartref, gan gynnwys eiddo prynu i osod, yn talu 3% ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny'n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750, gan roi cyfradd dreth effeithiol o 4%."
     how_calculated_extra: "*Nid yw eiddo dan £40,000 yn destun SDLT ail gartref"
     describe_price_field: Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn.
     activemodel:

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -24,20 +24,23 @@ en:
       option_isSecondHome: buying an additional or buy-to-let property
     recalculate: Recalculate
     how_calculated_toggle: "How is this calculated?"
-    how_calculated: "First-time buyers are entitled to relief for the first £300,000 of Stamp Duty on properties up to a value of £500,000."
-    how_calculated_2: "For example, if you’re buying your first property for £350,000 you would pay:"
+    how_calculated_ftb: "First-time buyers are entitled to relief for the first £300,000 of Stamp Duty on properties up to a value of £500,000."
+    how_calculated_ftb_2: "For example, if you’re buying your first property for £350,000 you would pay:"
     how_calculated_ftb_list:
       - "no Stamp Duty on the value of the property up to £300,000"
       - "5% tax on the value between £300,001 and £350,000."
-    how_calculated_3: "In this case, the total amount of Stamp Duty would be £2,500, giving an effective rate of 0.7%."
-    how_calculated_4: "For properties priced over £500,000, no relief is available and you would pay Stamp Duty on the full purchase price."
-    how_calculated_5: "If you're buying your next home or buying a property valued at over £500,000 you would pay:"
-    how_calculated_default_list:
+    how_calculated_ftb_3: "In this case, the total amount of Stamp Duty would be £2,500, giving an effective rate of 0.7%."
+    how_calculated_ftb_4: "For properties priced over £500,000, no relief is available and you would pay Stamp Duty on the full purchase price."
+    how_calculated_ftb_5: "If you're buying your next home or buying a property valued at over £500,000 you would pay:"
+    how_calculated_ftb_default_list:
       - "no tax on the value of the property up to £125,000"
       - "2% tax on the property value between £125,001 and £250,000"
       - "5% tax on the property value between £250,001 and £550,000."
-    how_calculated_6: "In this case, the total amount of Stamp Duty would be £17,500, giving an effective tax rate of 3.2%."
-    how_calculated_7: "These rates currently apply to England, Wales and Northern Ireland"
+    how_calculated_ftb_6: "In this case, the total amount of Stamp Duty would be £17,500, giving an effective tax rate of 3.2%."
+    how_calculated_ftb_7: "These rates currently apply to England, Wales and Northern Ireland"
+    how_calculated_ftb_extra: "* Properties under £40,000 are not subject to second home SDLT"
+    how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400 giving an effective tax rate of 1%."
+    how_calculated_additional: "Anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
     how_calculated_extra: "* Properties under £40,000 are not subject to second home SDLT"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -24,8 +24,20 @@ en:
       option_isSecondHome: buying an additional or buy-to-let property
     recalculate: Recalculate
     how_calculated_toggle: "How is this calculated?"
-    how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400 giving an effective tax rate of 1%."
-    how_calculated_additional: "Anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
+    how_calculated: "First-time buyers are entitled to relief for the first £300,000 of Stamp Duty on properties up to a value of £500,000."
+    how_calculated_2: "For example, if you’re buying your first property for £350,000 you would pay:"
+    how_calculated_ftb_list:
+      - "no Stamp Duty on the value of the property up to £300,000"
+      - "5% tax on the value between £300,001 and £350,000."
+    how_calculated_3: "In this case, the total amount of Stamp Duty would be £2,500, giving an effective rate of 0.7%."
+    how_calculated_4: "For properties priced over £500,000, no relief is available and you would pay Stamp Duty on the full purchase price."
+    how_calculated_5: "If you're buying your next home or buying a property valued at over £500,000 you would pay:"
+    how_calculated_default_list:
+      - "no tax on the value of the property up to £125,000"
+      - "2% tax on the property value between £125,001 and £250,000"
+      - "5% tax on the property value between £250,001 and £550,000."
+    how_calculated_6: "In this case, the total amount of Stamp Duty would be £17,500, giving an effective tax rate of 3.2%."
+    how_calculated_7: "These rates currently apply to England, Wales and Northern Ireland"
     how_calculated_extra: "* Properties under £40,000 are not subject to second home SDLT"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:
@@ -47,6 +59,7 @@ en:
       property_price_header: "Purchase price of property"
       rate_header: "Rate of Stamp Duty"
       extra_rate_header: "Buy to Let/ Additional Home Rate*"
+      standard_rates_apply: "Standard rates apply (see below)"
       over: Over
       million: million
     next_steps:


### PR DESCRIPTION
# Change 'how is this calculated?' text 

[TP Ticket](https://moneyadviceservice.tpondemand.com/entity/8709)

**Description**

Because Stamp Duty is calculated differently for First-time buyers, we need to change the details in the 'how is this calculated' expandable, for users who are first-time buyers.

What should happen is that first time buyers should see the content in the ticket (all of it), and 2nd home & next home buyers should see the original contents (not changed).

| First time buyers | Next home |
|--------|------|
|![image](https://user-images.githubusercontent.com/13165846/33477264-f58c5898-d67c-11e7-8392-12c908e3b975.png)|![image](https://user-images.githubusercontent.com/13165846/33477232-da8ada2e-d67c-11e7-9b33-5521af80d364.png)|


