### PR TITLE
[DEV APPROVED]Hide budget warning for JS users

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -28,6 +28,12 @@
   }
 }
 
+.stamp-duty__budget-warning {
+  .js & {
+    display: none;
+  }
+}
+
 .stamp-duty__explanation-firsttimebuyer,
 .stamp-duty__explanation-nexthome {
   display: none;

--- a/app/views/mortgage_calculator/stamp_duties/_budget_warning.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_budget_warning.html.erb
@@ -1,4 +1,4 @@
-<div class="global-alert global-alert--warning">
+<div class="global-alert global-alert--warning stamp-duty__budget-warning">
   <div class="global-alert__content-container">
     <strong class="global-alert__heading">
       <%= t('mortgage_calculator.budget_warning.heading') %>


### PR DESCRIPTION
# Hide budget warning for JS users

This is a tiny PR that hides the budget warning for JS users only, this will enable us to deploy client side changes sooner (If necessary).

![image](https://user-images.githubusercontent.com/13165846/33479366-bd5c98cc-d684-11e7-8fb9-9105b56d7a26.png)
