### PR TITLE
[DEV APPROVED] Replace hard coded value with variable in translation files

### DIFF
--- a/app/helpers/mortgage_calculator/stamp_duties_helper.rb
+++ b/app/helpers/mortgage_calculator/stamp_duties_helper.rb
@@ -11,6 +11,12 @@ module MortgageCalculator
       )
     end
 
+    def ftb_threshold
+      formatted_currency(
+        MortgageCalculator::StampDuty::FIRST_TIME_BUYER_THRESHOLD
+      )
+    end
+
     private
     def maximum_band(num)
       I18n.t('stamp_duty.table.over_million', number: num/1_000_000.to_f)

--- a/app/views/mortgage_calculator/stamp_duties/_calculation_explanation.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_calculation_explanation.html.erb
@@ -1,5 +1,5 @@
 <div class="stamp-duty__explanation-firsttimebuyer">
-  <p><%= I18n.t("stamp_duty.how_calculated_ftb") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb", amount: ftb_threshold) %></p>
   <p><%= I18n.t("stamp_duty.how_calculated_ftb_2") %></p>
   <ul class="list stamp-duty__calculation-explanation-list">
     <% I18n.t("stamp_duty.how_calculated_ftb_list").each do |ftb_list| %>
@@ -7,7 +7,7 @@
     <% end %>
   </ul>
   <p><%= I18n.t("stamp_duty.how_calculated_ftb_3") %></p>
-  <p><%= I18n.t("stamp_duty.how_calculated_ftb_4") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_4", amount: ftb_threshold) %></p>
   <table class="mortgagecalc__table stamp-duty__table">
     <thead>
       <tr>
@@ -30,7 +30,7 @@
       </tr>
     </tbody>
   </table>
-  <p><%= I18n.t("stamp_duty.how_calculated_ftb_5") %></p>
+  <p><%= I18n.t("stamp_duty.how_calculated_ftb_5", amount: ftb_threshold) %></p>
   <ul class="list stamp-duty__calculation-explanation-list">
     <% I18n.t("stamp_duty.how_calculated_ftb_default_list").each do |default_list| %>
       <li><%= default_list %></li>

--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
@@ -16,7 +16,7 @@
 
   <p class="rendered-from-js stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence_prefix") %> {{ stampDuty.percentageTax() | number: 1 }}<%= I18n.t("stamp_duty.results.sentence_suffix") %></p>
 
-  <p class="stamp-duty__FTB_conditional"><%= I18n.t("stamp_duty.results.FTB_conditional") %></p>
+  <p class="stamp-duty__FTB_conditional"><%= I18n.t("stamp_duty.results.FTB_conditional", amount: ftb_threshold) %></p>
 
   <div>
     <a href="#" class="rendered-from-js expander expander--nudge" ng-class="{ 'expander--expanded' : expandedStampDutyInformation }" ng-click="toggleStampDutyExpanded($event)" affects-height="click">

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -25,14 +25,14 @@ cy:
       option_isSecondHome: prynu eiddo atodol neu eiddo prynu-i-osod
     recalculate: Ailgyfrifo
     how_calculated_toggle: "Sut y cyfrifir hyn?"
-    how_calculated_ftb: "Mae prynwyr tro cyntaf yn gymwys i gael gostyngiad Treth Stamp ar y £300,000 cyntaf ar eiddo sy'n werth hyd at £500,000."
+    how_calculated_ftb: "Mae prynwyr tro cyntaf yn gymwys i gael gostyngiad Treth Stamp ar y £300,000 cyntaf ar eiddo sy'n werth hyd at %{amount}."
     how_calculated_ftb_2: "Er enghraifft, os ydych chi'n prynu eich eiddo cyntaf am £350,000 byddech yn talu:"
     how_calculated_ftb_list:
       - "dim Treth Stamp ar werth yr eiddo hyd at £300,000"
       - "5% o dreth ar y gwerth rhwng £300,001 a £350,000."
     how_calculated_ftb_3: "Yn yr achos hwn, byddai cyfanswm y Dreth Stamp yn £2,500, gan roi cyfradd effeithiol o 0.7%."
-    how_calculated_ftb_4: "Ar gyfer eiddo wedi eu prisio dros £500,000, nid oes gostyngiad ar gael a byddech yn talu Treth Stamp ar y pris prynu llawn."
-    how_calculated_ftb_5: "Os ydych chi'n prynu eich cartref nesaf neu'n prynu eiddo wedi ei brisio dros £500,000, byddech yn talu:"
+    how_calculated_ftb_4: "Ar gyfer eiddo wedi eu prisio dros %{amount}, nid oes gostyngiad ar gael a byddech yn talu Treth Stamp ar y pris prynu llawn."
+    how_calculated_ftb_5: "Os ydych chi'n prynu eich cartref nesaf neu'n prynu eiddo wedi ei brisio dros %{amount}, byddech yn talu:"
     how_calculated_ftb_default_list:
       - "dim treth ar werth yr eiddo hyd at £125,000"
       - "2% o dreth ar werth yr eiddo rhwng £125,001 a £250,000"
@@ -57,7 +57,7 @@ cy:
       sentence_prefix: "Y gyfradd dreth effeithiol yw"
       sentence_suffix: "%"
       click_to_expand: Cliciwch i ehangu
-      FTB_conditional: "Nid ydych yn gymwys i gael gostyngiad ar Dreth Stamp oherwydd mae gwerth yr eiddo yn fwy na £500,000."
+      FTB_conditional: "Nid ydych yn gymwys i gael gostyngiad ar Dreth Stamp oherwydd mae gwerth yr eiddo yn fwy na %{amount}."
     table:
       property_price_header: "Pris Prynu"
       rate_header: "Cyfradd treth stamp"

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -24,14 +24,14 @@ en:
       option_isSecondHome: buying an additional or buy-to-let property
     recalculate: Recalculate
     how_calculated_toggle: "How is this calculated?"
-    how_calculated_ftb: "First-time buyers are entitled to relief for the first £300,000 of Stamp Duty on properties up to a value of £500,000."
+    how_calculated_ftb: "First-time buyers are entitled to relief for the first £300,000 of Stamp Duty on properties up to a value of %{amount}."
     how_calculated_ftb_2: "For example, if you’re buying your first property for £350,000 you would pay:"
     how_calculated_ftb_list:
       - "no Stamp Duty on the value of the property up to £300,000"
       - "5% tax on the value between £300,001 and £350,000."
     how_calculated_ftb_3: "In this case, the total amount of Stamp Duty would be £2,500, giving an effective rate of 0.7%."
-    how_calculated_ftb_4: "For properties priced over £500,000, no relief is available and you would pay Stamp Duty on the full purchase price."
-    how_calculated_ftb_5: "If you're buying your next home or buying a property valued at over £500,000 you would pay:"
+    how_calculated_ftb_4: "For properties priced over %{amount}, no relief is available and you would pay Stamp Duty on the full purchase price."
+    how_calculated_ftb_5: "If you're buying your next home or buying a property valued at over %{amount} you would pay:"
     how_calculated_ftb_default_list:
       - "no tax on the value of the property up to £125,000"
       - "2% tax on the property value between £125,001 and £250,000"
@@ -56,7 +56,7 @@ en:
       sentence_prefix: "The effective tax rate is"
       sentence_suffix: "%"
       click_to_expand: Click to expand.
-      FTB_conditional: "You are not eligible for relief on Stamp Duty because the property value is greater than £500,000."
+      FTB_conditional: "You are not eligible for relief on Stamp Duty because the property value is greater than %{amount}."
     table:
       property_price_header: "Purchase price of property"
       rate_header: "Rate of Stamp Duty"

--- a/spec/helpers/stamp_duties_helper_spec.rb
+++ b/spec/helpers/stamp_duties_helper_spec.rb
@@ -21,5 +21,11 @@ module MortgageCalculator
         expect(second_home_threshold).to eq('£40,000')
       end
     end
+
+    describe '#ftb_threshold' do
+      it 'returns the first time buyer threshold formatted with a currency sign' do
+        expect(ftb_threshold).to eq('£500,000')
+      end
+    end
   end
 end


### PR DESCRIPTION
There is a constant already defined for the First Time Buyer threshold. This pr uses that constant in the translation files instead of the hard coded value.