### PR TITLE
[DEV APPROVED] 8708 Fixes YAML indentation issue

### DIFF
--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -4,8 +4,8 @@ cy:
       title: "Cyfrifiannell Treth Stamp - Cyfrifwch y cyfraddau newydd a ddiweddarwyd ar gyfer Treth Dir y Doll Stamp"
       description: "Defnyddiwch ein cyfrifiannell Treth Stamp i gael amcangyfrif o faint o Dreth Dir y Doll Stamp y bydd angen i chi ei thalu ar eich cartref newydd yn seiliedig ar y cyfraddau newydd a ddiweddarwyd"
       canonical_url: "https://www.moneyadviceservice.org.uk/cy/tools/prynu-ty/cyfrifiannell-treth-stamp"
-      tooltip_show: sioe help
-      tooltip_hide: cuddio cymorth
+    tooltip_show: sioe help
+    tooltip_hide: cuddio cymorth
     tool_name: "cyfrifiannell-treth-stamp"
     pretitle: "Defnyddiwch y gyfrifiannell hon i gyfrifo faint o dreth stamp y bydd angen ichi ei thalu ar gartref newydd"
     heading: "Cyfrifiannell treth stamp"

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -4,8 +4,8 @@ en:
       title: "Stamp Duty Calculator - Work out the new updated Stamp Duty Land Tax rates"
       description: "Use our Stamp Duty calculator to get an estimate of how much Stamp Duty Land Tax you’ll need to pay on your new home based on the new updated rates"
       canonical_url: "https://www.moneyadviceservice.org.uk/en/tools/house-buying/stamp-duty-calculator"
-      tooltip_show: show help
-      tooltip_hide: hide help
+    tooltip_show: show help
+    tooltip_hide: hide help
     tool_name: "stamp-duty-calculator"
     pretitle: Use this calculator to work out much Stamp Duty you’ll need to pay on a new home
     heading: "Stamp Duty calculator"

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 2
     MINOR = 1
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
## Issue
This PR fixes an issue wth indentation in the stamp duty YAML file. 
The extra indentation was preventing the view from finding the EN and CY for:
`tooltip_show:`
`tooltip_hide:`

## Solution
Fix indentation in both EN and CY YAML files.
Bump version with a patch to 2.1.1