### PR TITLE
[DEV APPROVED] TP: 8736, Comment: Updates rounding in calculation

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
@@ -89,7 +89,7 @@ App.factory('StampDuty', function() {
           totalTax += this.propertyPrice * (SECOND_HOME_TAX_RATE / 100);
         }
 
-        return totalTax;
+        return Math.floor(totalTax);
       },
 
       totalPurchase : function() {

--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
@@ -9,7 +9,7 @@
       <span ng-if="!stampDuty.isSecondHome"><%= I18n.t("stamp_duty.results.title") %></span>
     </div>
     <span ng-hide="js"><%= number_to_currency @stamp_duty.tax_due_formatted %></span>
-    <span class="rendered-from-js">{{ stampDuty.cost() | customCurrency:"£" }}</span>
+    <span class="rendered-from-js">{{ stampDuty.cost() | customCurrency:"£":"whole" }}</span>
   </div>
 
   <p ng-hide="js" class="stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence", percentage: number_to_percentage(@stamp_duty.percentage_tax, precision: 1)) %></p>

--- a/spec/javascripts/unit/services/stampDuty.js
+++ b/spec/javascripts/unit/services/stampDuty.js
@@ -60,6 +60,14 @@ describe('Service: StampDuty', function () {
       expect(stampDuty.totalPurchase()).toBe(352500);
     });
 
+    it('when house price is 400012', function() {
+      setPrice(400012);
+
+      expect(stampDuty.cost()).toBe(5000);
+      expect(stampDuty.percentageTax()).toBeCloseTo(1.2, 1);
+      expect(stampDuty.totalPurchase()).toBe(405012);
+    });
+
     it('when house price is 450000', function() {
       setPrice(450000);
 
@@ -120,6 +128,14 @@ describe('Service: StampDuty', function () {
       expect(stampDuty.cost()).toBe(3750.00);
       expect(stampDuty.percentageTax()).toBeCloseTo(1.4, 1);
       expect(stampDuty.totalPurchase()).toBe(278750);
+    });
+
+    it('when house price is 300019', function() {
+      setPrice(300019);
+
+      expect(stampDuty.cost()).toBe(5000.00);
+      expect(stampDuty.percentageTax()).toBeCloseTo(1.7, 1);
+      expect(stampDuty.totalPurchase()).toBe(305019);
     });
 
     it('when house price is 510000.00', function() {
@@ -206,6 +222,14 @@ describe('Service: StampDuty', function () {
       expect(stampDuty.cost()).toBe(65625);
       expect(stampDuty.percentageTax()).toBeCloseTo(7.00, 2);
       expect(stampDuty.totalPurchase()).toBe(1003125.00);
+    });
+
+    it('when house price is 988882', function() {
+      setPrice(988882);
+
+      expect(stampDuty.cost()).toBe(72304);
+      expect(stampDuty.percentageTax()).toBeCloseTo(7.31, 2);
+      expect(stampDuty.totalPurchase()).toBe(1061186);
     });
 
     it('when house price is 2100000.00', function() {


### PR DESCRIPTION
[TP8736](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8736)

This addresses a problem that has become apparent in the Stamp Duty Calculator. 

Currently the tool displays a value for the payable Stamp Duty that includes the number of pence, e.g. for a user buying their next home valued at £300,019 the result is displayed as £5,000.95. 

![image](https://user-images.githubusercontent.com/6080548/33881479-cd3d6842-df2c-11e7-9741-7d14184ddfe0.png)

This PR ensures that the value is rounded down to the nearest whole pound.

![image](https://user-images.githubusercontent.com/6080548/33884379-5312e7f8-df37-11e7-88e3-ca65bd1ab73e.png)
