### PR TITLE
[DEV APPROVED] Update Stamp duty no-JS view to show effective tax rate to 2dp

### DIFF
--- a/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_stamp_duty_to_pay_panel.html.erb
@@ -12,7 +12,7 @@
     <span class="rendered-from-js">{{ stampDuty.cost() | customCurrency:"£":"whole" }}</span>
   </div>
 
-  <p ng-hide="js" class="stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence", percentage: number_to_percentage(@stamp_duty.percentage_tax, precision: 1)) %></p>
+  <p ng-hide="js" class="stamp-duty__results-tax-rate ng-hide"><%= I18n.t("stamp_duty.results.sentence", percentage: number_to_percentage(@stamp_duty.percentage_tax, precision: 2)) %></p>
 
   <p class="rendered-from-js stamp-duty__results-tax-rate"><%= I18n.t("stamp_duty.results.sentence_prefix") %> {{ stampDuty.percentageTax() | number: 2 }}<%= I18n.t("stamp_duty.results.sentence_suffix") %></p>
 

--- a/features/stamp_duty_buying_next_home.feature
+++ b/features/stamp_duty_buying_next_home.feature
@@ -3,28 +3,30 @@ So that I know how much stamp duty to pay
 As a user buying my next home
 I want to enter my house price
 
-Scenario Outline: stamp duty for next home
+Background:
   Given I visit the Stamp Duty page
+
+Scenario Outline: stamp duty for next home
   When I enter a house price of <price>
   And I am a next time buyer
   And I click next
   Then I see the title for the results page
-  Then I see the stamp duty I will have to pay is "£<duty>"
+  And I see the stamp duty I will have to pay is "£<duty>"
+  And I see the effective tax rate is "<effective tax>"
 
 Examples:
-  | price   | duty   |
-  | 39000   | 0      |
-  | 40000   | 0      |
-  | 120000  | 0      |
-  | 126000  | 20     |
-  | 260000  | 3,000  |
-  | 350000  | 7,500  |
-  | 450000  | 12,500 |
-  | 550000  | 17,500 |
+  | price   | duty   | effective tax |
+  | 39000   | 0      | 0.00%         |
+  | 40000   | 0      | 0.00%         |
+  | 120000  | 0      | 0.00%         |
+  | 126000  | 20     | 0.02%         |
+  | 260000  | 3,000  | 1.15%         |
+  | 350000  | 7,500  | 2.14%         |
+  | 450000  | 12,500 | 2.78%         |
+  | 550000  | 17,500 | 3.18%         |
 
 @javascript
 Scenario Outline: stamp duty for next home
-  Given I visit the Stamp Duty page
   When I enter a house price of <price>
   And I am a next time buyer
   And I click next
@@ -44,7 +46,6 @@ Examples:
 
 
 Scenario: I recalculate for next home
-  Given I visit the Stamp Duty page
   When I enter a house price of 260000
   And I am a next time buyer
   And I click next
@@ -55,7 +56,6 @@ Scenario: I recalculate for next home
 
 @javascript
 Scenario: I recalculate for next home
-  Given I visit the Stamp Duty page
   When I enter a house price of 260000
   And I am a next time buyer
   And I click next

--- a/features/step_definitions/stamp_duty.rb
+++ b/features/step_definitions/stamp_duty.rb
@@ -95,3 +95,7 @@ Then(/^I should see the stamp duty percentages for first time buyers as:$/) do |
   expect(@stamp_duty.info_table).to have_content(data[4])
   expect(@stamp_duty.info_table).to have_content(data[5])
 end
+
+Then("I see the effective tax rate is {string}") do |string|
+  expect(@stamp_duty.effective_tax).to have_content(string)
+end

--- a/features/support/ui/pages/stamp_duty.rb
+++ b/features/support/ui/pages/stamp_duty.rb
@@ -16,6 +16,7 @@ module UI
       element :results, "p[class='results']"
       element :results_text, "p[class='results-text']"
       element :recalculate, "form.step_two input[type=submit]"
+      element :effective_tax, "p.stamp-duty__results-tax-rate.ng-hide"
     end
 
     class WelshStampDuty < StampDuty


### PR DESCRIPTION
[TP-8739](https://moneyadviceservice.tpondemand.com/entity/8739)

Stamp duty effective rate should be shown to 2dp
Before
![stamp_duty_calculator_-_work_out_the_new_updated_stamp_duty_land_tax_rates_-_money_advice_service](https://user-images.githubusercontent.com/7126705/33900110-58dedf4c-df65-11e7-8725-773af130c3c5.png)

After
![dummy](https://user-images.githubusercontent.com/7126705/33900053-2e93192e-df65-11e7-9c30-62085d79620e.png)

