### PR TITLE
[DEV APPROVED] 8648 Update 'Next steps' content in the mortgage affordability calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Mortgage Calculator
 
 Rails engine, providing a suite of calculators to determine affordability.
 
+[Technical docs](https://github.com/moneyadviceservice/technical-docs/tree/master/mortgage_calculator)
+
 
 ## Installation
 

--- a/app/controllers/mortgage_calculator/affordabilities_controller.rb
+++ b/app/controllers/mortgage_calculator/affordabilities_controller.rb
@@ -36,7 +36,14 @@ module MortgageCalculator
     end
 
     def next_steps
-      @risk_level = affordability_model.risk_level
+      affordability = affordability_model
+
+      @risk_level =
+        if affordability.empty?
+          :default
+        else
+          affordability.risk_level
+        end
     end
 
     def tool_name

--- a/app/controllers/mortgage_calculator/affordabilities_controller.rb
+++ b/app/controllers/mortgage_calculator/affordabilities_controller.rb
@@ -36,6 +36,7 @@ module MortgageCalculator
     end
 
     def next_steps
+      @risk_level = affordability_model.risk_level
     end
 
     def tool_name
@@ -72,4 +73,3 @@ module MortgageCalculator
       helper_method :interest_rate_change_amount
   end
 end
-

--- a/app/views/mortgage_calculator/affordabilities/_default_risk_next_steps.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_default_risk_next_steps.html.erb
@@ -1,0 +1,38 @@
+<h4 class="mortgagecalc__heading"><%= t("affordability.next_steps.default.title") %></h4>
+
+<ol class="featured-list">
+  <li>
+    <strong><%= t("affordability.next_steps.default.tip_1.heading") %></strong>
+    <%= link_to(
+          t("affordability.next_steps.default.tip_1.info_html"),
+          t("affordability.next_steps.default.tip_1.url"),
+          target: "_blank",
+          rel: no_follow?
+        )
+    %>
+  </li>
+  <li>
+    <strong><%= t("affordability.next_steps.default.tip_2.heading") %></strong>
+    <%= t("affordability.next_steps.default.tip_2.info_html",
+          budget_planner: link_to(
+            t("affordability.next_steps.default.tip_2.url_text"),
+            t("affordability.next_steps.default.tip_2.url"),
+            target: "_blank",
+            rel: no_follow?
+          )
+        )
+    %>
+  </li>
+  <li>
+    <strong><%= t("affordability.next_steps.default.tip_3.heading") %></strong>
+    <%= t("affordability.next_steps.default.tip_3.info_html",
+          saving: link_to(
+            t("affordability.next_steps.default.tip_3.url_text"),
+            t("affordability.next_steps.default.tip_3.url"),
+            target: "_blank",
+            rel: no_follow?
+          )
+        )
+    %>
+  </li>
+</ol>

--- a/app/views/mortgage_calculator/affordabilities/_high_risk_next_steps.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_high_risk_next_steps.html.erb
@@ -1,0 +1,42 @@
+<h4 class="mortgagecalc__heading"><%= t("affordability.next_steps.high.title") %></h4>
+
+<ol class="featured-list">
+  <li>
+    <strong><%= t("affordability.next_steps.high.tip_1.heading") %></strong>
+    <%= t("affordability.next_steps.high.tip_1.info_html",
+      deposit: link_to(
+        t("affordability.next_steps.high.tip_1.url_text_1"),
+        t("affordability.next_steps.high.tip_1.url_1"),
+        target: "_blank",
+        rel: no_follow?
+      ),
+      ratios: link_to(
+        t("affordability.next_steps.high.tip_1.url_text_2"),
+        t("affordability.next_steps.high.tip_1.url_2"),
+        target: "_blank",
+        rel: no_follow?)
+      )
+    %>
+  </li>
+  <li>
+    <strong><%= t("affordability.next_steps.high.tip_2.heading") %></strong>
+    <%= link_to(
+          t("affordability.next_steps.high.tip_2.info_html"),
+          t("affordability.next_steps.high.tip_2.url"),
+          target: "_blank",
+          rel: no_follow?
+        )
+    %>
+  </li>
+  <li>
+    <strong><%= t("affordability.next_steps.high.tip_3.heading") %></strong>
+    <%= t("affordability.next_steps.high.tip_3.info_html",
+      budget_planner: link_to(
+        t("affordability.next_steps.high.tip_3.url_text"),
+        t("affordability.next_steps.high.tip_3.url"),
+        target: "_blank",
+        rel: no_follow?)
+      )
+    %>
+  </li>
+</ol>

--- a/app/views/mortgage_calculator/affordabilities/_low_risk_next_steps.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_low_risk_next_steps.html.erb
@@ -1,0 +1,36 @@
+<h4 class="mortgagecalc__heading"><%= t("affordability.next_steps.low.title") %></h4>
+
+<ol class="featured-list">
+  <li>
+    <strong><%= t("affordability.next_steps.low.tip_1.heading") %></strong>
+    <%= link_to(
+          t("affordability.next_steps.low.tip_1.info_html"),
+          t("affordability.next_steps.low.tip_1.url"),
+          target: "_blank",
+          rel: no_follow?
+        )
+    %>
+  </li>
+  <li>
+    <strong><%= t("affordability.next_steps.low.tip_2.heading") %></strong>
+    <%= link_to(
+          t("affordability.next_steps.low.tip_2.info_html"),
+          t("affordability.next_steps.low.tip_2.url"),
+          target: "_blank",
+          rel: no_follow?
+        )
+    %>
+  </li>
+  <li>
+    <strong><%= t("affordability.next_steps.low.tip_3.heading") %></strong>
+    <%= t("affordability.next_steps.low.tip_3.info_html",
+          steps: link_to(
+            t("affordability.next_steps.low.tip_3.url_text"),
+            t("affordability.low.next_steps.tip_3.url"),
+            target: "_blank",
+            rel: no_follow?
+          )
+        )
+    %>
+  </li>
+</ol>

--- a/app/views/mortgage_calculator/affordabilities/_medium_risk_next_steps.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_medium_risk_next_steps.html.erb
@@ -1,0 +1,35 @@
+<h4 class="mortgagecalc__heading"><%= t("affordability.next_steps.medium.title") %></h4>
+
+<ol class="featured-list">
+  <li>
+    <strong><%= t("affordability.next_steps.medium.tip_1.heading") %></strong>
+    <%= link_to(
+          t("affordability.next_steps.medium.tip_1.info_html"),
+          t("affordability.next_steps.medium.tip_1.url"),
+          target: "_blank",
+          rel: no_follow?
+        )
+    %>
+  </li>
+  <li>
+    <strong><%= t("affordability.next_steps.medium.tip_2.heading") %></strong>
+    <%= t("affordability.next_steps.medium.tip_2.info_html",
+          budget_planner: link_to(
+            t("affordability.next_steps.medium.tip_2.url_text"),
+            t("affordability.next_steps.medium.tip_2.url"),
+            target: "_blank",
+            rel: no_follow?)
+          )
+    %>
+  </li>
+  <li>
+    <strong><%= t("affordability.next_steps.medium.tip_3.heading") %></strong>
+    <%= link_to(
+          t("affordability.next_steps.medium.tip_3.info_html"),
+          t("affordability.next_steps.medium.tip_3.url"),
+          target: "_blank",
+          rel: no_follow?
+        )
+    %>
+  </li>
+</ol>

--- a/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_next_steps_content.html.erb
@@ -1,11 +1,5 @@
 <div class="affcalc__col--clip">
-  <h4 class="mortgagecalc__heading"><%= t("affordability.next_steps.title") %></h4>
-  
-  <ol class="featured-list">
-    <li><strong><%= t("affordability.next_steps.tip_1.heading") %></strong> <%= link_to t("affordability.next_steps.tip_1.info_html"), t("affordability.next_steps.tip_1.url"), target: "_blank", rel: no_follow? %></li>
-    <li><strong><%= t("affordability.next_steps.tip_2.heading") %></strong> <%= t("affordability.next_steps.tip_2.info_html", budget_planner: link_to(t("affordability.next_steps.tip_2.url_text"), t("affordability.next_steps.tip_2.url"), target: "_blank", rel: no_follow?)) %></li>
-    <li><strong><%= t("affordability.next_steps.tip_3.heading") %></strong> <%= t("affordability.next_steps.tip_3.info_html", saving: link_to(t("affordability.next_steps.tip_3.url_text"), t("affordability.next_steps.tip_3.url"), target: "_blank", rel: no_follow?)) %></li>
-  </ol>
+  <%= render "#{risk_level}_risk_next_steps" %>
 </div>
 
 <div class="affcalc__row">

--- a/app/views/mortgage_calculator/affordabilities/next_steps.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/next_steps.html.erb
@@ -3,5 +3,5 @@
     <h2><%= I18n.t("affordability.title") %></h2>
   </div>
 
-  <%= render 'next_steps_content'  %>
+  <%= render 'next_steps_content', risk_level: @risk_level %>
 </div>

--- a/config/locales/affordability.cy.yml
+++ b/config/locales/affordability.cy.yml
@@ -169,21 +169,54 @@ cy:
       only_rent_and_mortgage_html: "Rydym angen mwy o wybodaeth gennych chi. Gwiriwch eich bod wedi rhoi’r holl symiau ar gyfer <strong>costau sefydlog ac ymroddedig</strong> ar y dudalen flaenorol neu ni fydd eich canlyniadau ar y dudalen hon yn gywir. %{back} i wneud hynny nawr."
       missing_lifestyle_costs_html: "Nid ydych wedi rhoi unrhyw symiau ar gyfer <strong>costau byw</strong> ar y dudalen flaenorol. Ydych chi’n siŵr bod hyn yn gywir? Os nad, efallai y bydd y canlyniadau ar y dudalen hon yn anghywir. %{back} ac unioni hyn nawr."
     next_steps:
-      title: "Tri cham i ganfod morgais fforddiadwy"
-      tip_1:
-        heading: "Am beth fydd benthycwyr yn chwilio wrth ymgeisio"
-        info_html: "Faint allwch chi fforddio ei fenthyca mewn gwirionedd?"
-        url: "https://www.moneyadviceservice.org.uk/cy/articles/faint-allwch-chi-fforddio-ei-fenthyca"
-      tip_2:
-        heading: "Gwneud newidiadau i’ch gwariant"
-        info_html: "Darllenwch ein %{budget_planner} i gael y darlun llawn"
-        url_text: "Cynllunydd Cyllideb"
-        url: "https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb"
-      tip_3:
-        heading: "Ystyriwch fenthyca llai"
-        info_html: "Ceisiwch %{saving}, neu chwilio am eiddo mewn ardal fwy fforddiadwy"
-        url: "https://www.moneyadviceservice.org.uk/cy/tools/cynilo-ar-gyfer-blaendal"
-        url_text: "cynilo ar gyfer blaendal mwy"
+      low:
+        title: "Tri cham i ganfod morgais fforddiadwy"
+        tip_1:
+          heading: "Gwnewch yn siŵr eich bod yn cael y morgais gorau ar eich cyfer chi"
+          info_html: "Deall gwahanol fathau o forgeisi"
+          url: "https://www.moneyadviceservice.org.uk/cy/categories/types-of-mortgage"
+        tip_2:
+          heading: "Peidiwch â gwneud y camgymeriadau hyn"
+          info_html: "Prynu cartref: sut i osgoi’r camgymeriadau mwyaf cyffredin"
+          url: "https://www.moneyadviceservice.org.uk/cy/articles/prynu-cartref-sut-i-osgoir-camgymeriadau-mwyaf-cyffredin"
+        tip_3:
+          heading: "Dechreuwch arni gyda’ch cais"
+          info_html: "Y broses o brynu tŷ – %{steps}"
+          url_text: "camau i brynu tŷ neu fflat newydd"
+          url: "https://www.moneyadviceservice.org.uk/cy/articles/llinell-amser-arian-wrth-brynu-cartref"
+      medium:
+        title: "Beth ddylech chi ei wneud nesaf"
+        tip_1:
+          heading: "Edrychwch ar wahanol gynlluniau i’ch helpu i brynu cartref"
+          info_html: "Cynlluniau llywodraeth ar gyfer prynwyr am y tro cyntaf a pherchnogion tai cyfredol"
+          url: "https://www.moneyadviceservice.org.uk/cy/articles/homebuy-firstbuy-a-chynlluniau-tai-fforddiadwy-eraill"
+        tip_2:
+          heading: "Rhowch drefn ar eich arian"
+          info_html: "Defnyddiwch ein %{budget_planner} i gael y darlun llawn"
+          url_text: "Cynllunydd Cyllideb"
+          url: "https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb/start"
+        tip_3:
+          heading: "Deallwch yr holl gostau"
+          info_html: "Gwnewch yn siŵr eich bod yn deall yr holl gostau cychwynnol o brynu cartref"
+          url: "https://www.moneyadviceservice.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
+      high:
+        title: "Tri cham i wneud eich morgais yn fwy fforddiadwy"
+        tip_1:
+          heading: "Ystyriwch fenthyca llai"
+          info_html: "Dysgwch am %{deposit} a %{ratios}"
+          url_text_1: "gynilo i gael blaendal"
+          url_1: "https://www.moneyadviceservice.org.uk/cy/articles/arbed-arian-ar-gyfer-blaendal"
+          url_text_2: "chymarebau benthyciad i werth"
+          url_2: "https://www.moneyadviceservice.org.uk/cy/articles/faint-allwch-chi-fforddio-ei-fenthyca"
+        tip_2:
+          heading: "Edrychwch ar wahanol gynlluniau i’ch helpu i brynu cartref"
+          info_html: "Cynlluniau llywodraeth ar gyfer prynwyr am y tro cyntaf a pherchnogion tai cyfredol"
+          url: "https://www.moneyadviceservice.org.uk/cy/articles/homebuy-firstbuy-a-chynlluniau-tai-fforddiadwy-eraill"
+        tip_3:
+          heading: "Rhowch drefn ar eich arian"
+          info_html: "Defnyddiwch ein %{budget_planner} i gael y darlun llawn"
+          url_text: "Cynllunydd Cyllideb"
+          url: "https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb/start"
       learn_more:
         title: "Fforddio eich morgais"
         tip_1: "Meddyliwch am wariant eich cartref yn ogystal â’ch taliadau morgais."

--- a/config/locales/affordability.en.yml
+++ b/config/locales/affordability.en.yml
@@ -217,6 +217,22 @@ en:
           info_html: "Use our %{budget_planner} to get the full picture"
           url_text: "Budger Planner"
           url: "https://www.moneyadviceservice.org.uk/en/tools/budget-planner"
+      default:
+        title: "Three steps to finding an affordable mortgage"
+        tip_1:
+          heading: "What lenders look for when you apply"
+          info_html: "How much can you really afford to borrow?"
+          url: "https://www.moneyadviceservice.org.uk/en/articles/how-much-can-you-afford-to-borrow"
+        tip_2:
+          heading: "Make changes to your spending"
+          info_html: "Use our %{budget_planner} to get the full picture"
+          url_text: "Budget Planner"
+          url: "https://www.moneyadviceservice.org.uk/en/tools/budget-planner"
+        tip_3:
+          heading: "Think about borrowing less"
+          info_html: "Try %{saving}, or look for property in a more affordable area"
+          url: "https://www.moneyadviceservice.org.uk/en/tools/saving-for-a-deposit"
+          url_text: "saving for a larger deposit"
       learn_more:
         title: "Affording your mortgage"
         tip_1: "Think about your household spend as well as your mortgage repayments."

--- a/config/locales/affordability.en.yml
+++ b/config/locales/affordability.en.yml
@@ -169,21 +169,54 @@ en:
       only_rent_and_mortgage_html: "We need more information from you. Please check that you have input all <strong>fixed and committed costs</strong> on the previous page or your results on this page will be incorrect. %{back} to do that now."
       missing_lifestyle_costs_html: "You haven’t entered any amounts for <strong>living costs</strong> on the previous page. Are you sure this is right? If not, the results on this page may be incorrect. %{back} and fix this now."
     next_steps:
-      title: "Three steps to finding an affordable mortgage"
-      tip_1:
-        heading: "What lenders look for when you apply"
-        info_html: "How much can you really afford to borrow?"
-        url: "https://www.moneyadviceservice.org.uk/en/articles/how-much-can-you-afford-to-borrow"
-      tip_2:
-        heading: "Make changes to your spending"
-        info_html: "Use our %{budget_planner} to get the full picture"
-        url_text: "Budget Planner"
-        url: "https://www.moneyadviceservice.org.uk/en/tools/budget-planner"
-      tip_3:
-        heading: "Think about borrowing less"
-        info_html: "Try %{saving}, or look for property in a more affordable area"
-        url: "https://www.moneyadviceservice.org.uk/en/tools/saving-for-a-deposit"
-        url_text: "saving for a larger deposit"
+      low:
+        title: "Three steps to finding an affordable mortgage"
+        tip_1:
+          heading: "Make sure you get the best mortgage for you"
+          info_html: "Understanding different types of mortgages"
+          url: "https://www.moneyadviceservice.org.uk/en/categories/types-of-mortgage"
+        tip_2:
+          heading: "Don’t make these mistakes"
+          info_html: "Buying a home: how to avoid the most common mistakes"
+          url: "https://www.moneyadviceservice.org.uk/en/articles/buying-a-home-how-to-avoid-the-most-common-mistakes"
+        tip_3:
+          heading: "Get started with your application"
+          info_html: "Home-buying process – %{steps}"
+          url_text: "steps to buying a new house or flat"
+          url: "https://www.moneyadviceservice.org.uk/en/articles/money-timeline-when-buying-property-england-wales--n-ireland"
+      medium:
+        title: "What you should do next"
+        tip_1:
+          heading: "Explore different schemes to help you buy a home"
+          info_html: "Government schemes for first-time home buyers and existing homeowners"
+          url: "https://www.moneyadviceservice.org.uk/en/articles/help-to-buy-homebuy-and-other-housing-schemes"
+        tip_2:
+          heading: "Take control of your money"
+          info_html: "Use our %{budget_planner} to get the full picture"
+          url_text: "Budger Planner"
+          url: "https://www.moneyadviceservice.org.uk/en/tools/budget-planner"
+        tip_3:
+          heading: "Understand all the costs"
+          info_html: "Make sure you understand all the up front costs of buying a home"
+          url: "https://www.moneyadviceservice.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
+      high:
+        title: "Three steps to making your mortgage more affordable"
+        tip_1:
+          heading: "Think about borrowing less"
+          info_html: "Learn about %{deposit} and %{ratios}"
+          url_text_1: "saving for a deposit"
+          url_1: "https://www.moneyadviceservice.org.uk/en/articles/saving-money-for-a-deposit"
+          url_text_2: "loan to value ratios"
+          url_2: "https://www.moneyadviceservice.org.uk/en/articles/how-much-can-you-afford-to-borrow"
+        tip_2:
+          heading: "Explore different schemes to help you buy a home"
+          info_html: "Government schemes for first-time home buyers and existing homeowners"
+          url: "https://www.moneyadviceservice.org.uk/en/articles/help-to-buy-homebuy-and-other-housing-schemes"
+        tip_3:
+          heading: "Take control of your money"
+          info_html: "Use our %{budget_planner} to get the full picture"
+          url_text: "Budger Planner"
+          url: "https://www.moneyadviceservice.org.uk/en/tools/budget-planner"
       learn_more:
         title: "Affording your mortgage"
         tip_1: "Think about your household spend as well as your mortgage repayments."

--- a/features/affordability.feature
+++ b/features/affordability.feature
@@ -172,3 +172,25 @@ Scenario: Adjusting the mortgage term via the slider
   When  I enter all details for single applicant
   Then  I should see the correct results for a single applicant
   And   I should be able to tweak the results by adjusting the mortgage term slider
+
+Scenario: Viewing next steps for medium risk
+  Given I visit the affordability page
+  When  I enter all details for single applicant at medium risk
+  And   I visit the next steps page
+  Then  I should see the medium risk next steps
+
+Scenario: Viewing next steps for low risk
+  Given I visit the affordability page
+  When  I enter all details for single applicant at low risk
+  And   I visit the next steps page
+  Then  I should see the low risk next steps
+
+Scenario: Viewing next steps for high risk
+  Given I visit the affordability page
+  When  I enter all details for single applicant at high risk
+  And   I visit the next steps page
+  Then  I should see the high risk next steps
+
+Scenario: Viewing next steps without completing the tool
+  When  I visit the next steps page without completing the tool
+  Then  I should see the default next steps

--- a/features/step_definitions/affordability.rb
+++ b/features/step_definitions/affordability.rb
@@ -377,3 +377,62 @@ end
 Then(/^I should see the repayment term tooltip$/) do
   expect(step_three).to have_term_years_tip
 end
+
+When("I enter all details for single applicant at medium risk") do
+  step_one.annual_income.set "100000"
+  step_one.extra_income.set "10000"
+  step_one.monthly_net_income.set "6000"
+  step_one.next.click
+  step_two.credit_repayments.set "300"
+  step_two.utilities.set "300"
+  step_two.childcare.set "300"
+  step_two.child_maintenance.set "300"
+  step_two.rent_and_mortgage.set "300"
+  step_two.food.set "300"
+  step_two.travel.set "300"
+  step_two.entertainment.set "300"
+  step_two.holiday.set "300"
+  step_two.next.click
+end
+
+When("I enter all details for single applicant at low risk") do
+  step_one.annual_income.set "100000"
+  step_one.extra_income.set "10000"
+  step_one.monthly_net_income.set "6000"
+  step_one.next.click
+  step_two.next.click
+end
+
+When("I enter all details for single applicant at high risk") do
+  step_one.annual_income.set "15000"
+  step_one.monthly_net_income.set "1000"
+  step_one.next.click
+  step_two.credit_repayments.set "200"
+  step_two.utilities.set "200"
+  step_two.childcare.set "200"
+  step_two.next.click
+end
+
+When("I visit the next steps page") do
+  step_three.next_steps.click
+end
+
+When("I visit the next steps page without completing the tool") do
+  next_steps.load
+end
+
+Then("I should see the medium risk next steps") do
+  expect(page).to have_content(I18n::t("affordability.next_steps.medium.title"))
+end
+
+Then("I should see the low risk next steps") do
+  expect(page).to have_content(I18n::t("affordability.next_steps.low.title"))
+end
+
+Then("I should see the high risk next steps") do
+  expect(page).to have_content(I18n::t("affordability.next_steps.high.title"))
+end
+
+Then("I should see the default next steps") do
+  expect(page).to have_content(I18n::t("affordability.next_steps.default.title"))
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,6 +19,10 @@ def step_three
   UI::Pages::Affordability::StepThree.new
 end
 
+def next_steps
+  UI::Pages::Affordability::NextSteps.new
+end
+
 def calculations
   require 'yaml'
 

--- a/features/support/ui/pages/affordabiity.rb
+++ b/features/support/ui/pages/affordabiity.rb
@@ -61,6 +61,7 @@ module UI
         set_url "/{locale}/mortgage_calculator/mortgage-affordability-calculator/step-3"
 
         element :recalculate, "input.recalculate-button"
+        element :next_steps, "a.button--primary"
 
         element :borrowing, "input[name='affordability[borrowing]']"
         element :term_years, "input[name='affordability[term_years]']"
@@ -94,6 +95,12 @@ module UI
         section :term_years_slider, UI::Sections::Slider, "#slider-term-years"
         section :interest_rate_slider, UI::Sections::Slider, "#slider-interest-rate"
         section :lifestyle_slider, UI::Sections::Slider, "#slider-lifestyle"
+      end
+
+      class NextSteps < SitePrism::Page
+        include DefaultLocale
+
+        set_url "/{locale}/mortgage_calculator/mortgage-affordability-calculator/next_steps"
       end
 
       class SyndicatedAffordability < SitePrism::Page

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 2
-    MINOR = 3
+    MINOR = 4
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')

--- a/spec/controllers/affordabilities_controller_spec.rb
+++ b/spec/controllers/affordabilities_controller_spec.rb
@@ -12,10 +12,10 @@ module MortgageCalculator
 
       it 'uses no-store header for caching' do
         get :step_1
-        expect(response.headers["Cache-Control"]).to eql("no-store")
+        expect(response.headers['Cache-Control']).to eql('no-store')
       end
 
-      it "persists and loads persisted data from the session" do
+      it 'persists and loads persisted data from the session' do
         post :step_1, affordability: { cat: 'meow' }
         get :step_1
         expect(session[:affordability]['cat']).to eq('meow')
@@ -25,10 +25,10 @@ module MortgageCalculator
     describe '#step_2' do
       it 'uses no-store header for caching' do
         get :step_2
-        expect(response.headers["Cache-Control"]).to eql("no-store")
+        expect(response.headers['Cache-Control']).to eql('no-store')
       end
 
-      it "persists and loads persisted data from the session" do
+      it 'persists and loads persisted data from the session' do
         post :step_2, affordability: { cat: 'meow' }
         get :step_2
         expect(session[:affordability]['cat']).to eq('meow')
@@ -38,42 +38,68 @@ module MortgageCalculator
     describe '#step_3' do
       it 'renders the step_3 template' do
         post :step_3, affordability: {
-                        people_attributes: {
-                          "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "6000"},
-                          "1"=>{annual_income: "50000", extra_income: "5000", monthly_net_income: "3000"}
-                        },
-                        outgoings: {}
-                      }
+          people_attributes: {
+            '0' => {
+              annual_income: '100000',
+              extra_income: '10000',
+              monthly_net_income: '6000'
+            },
+            '1' => {
+              annual_income: '50000',
+              extra_income: '5000',
+              monthly_net_income: '3000'
+            }
+          },
+          outgoings: {}
+        }
 
         expect(response).to be_success
         expect(response).to render_template('step_3')
       end
 
-      context "when custom borrowing amount is entered" do
+      context 'when custom borrowing amount is entered' do
         it 'sets custom house price' do
           post :step_3, affordability: {
-                          people_attributes: {
-                            "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "6000"},
-                            "1"=>{annual_income: "50000", extra_income: "5000", monthly_net_income: "3000"}
-                          },
-                          outgoings: {},
-                          borrowing: "550000"
-                        }
+            people_attributes: {
+              '0' => {
+                annual_income: '100000',
+                extra_income: '10000',
+                monthly_net_income: '6000'
+              },
+              '1' => {
+                annual_income: '50000',
+                extra_income: '5000',
+                monthly_net_income: '3000'
+              }
+            },
+            outgoings: {},
+            borrowing: '550000'
+          }
+
           expect(response).to be_success
-          expect(assigns(:affordability).borrowing.to_s).to eql("550000")
+          expect(assigns(:affordability).borrowing.to_s).to eql('550000')
         end
       end
 
-      context "when custom lifestyle amount is entered" do
+      context 'when custom lifestyle amount is entered' do
         it 'sets custom lifestyle amount' do
           post :step_3, affordability: {
-                          people_attributes: {
-                            "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "6000"},
-                            "1"=>{annual_income: "50000", extra_income: "5000", monthly_net_income: "3000"}
-                          },
-                          outgoings: {},
-                          lifestyle_costs: "3000"
-                        }
+            people_attributes: {
+              '0' => {
+                annual_income: '100000',
+                extra_income: '10000',
+                monthly_net_income: '6000'
+              },
+              '1' => {
+                annual_income: '50000',
+                extra_income: '5000',
+                monthly_net_income: '3000'
+              }
+            },
+            outgoings: {},
+            lifestyle_costs: '3000'
+          }
+
           expect(response).to be_success
           expect(assigns(:affordability).lifestyle_costs.to_i).to eql(3000)
         end
@@ -85,11 +111,15 @@ module MortgageCalculator
         context 'when at high risk' do
           it 'renders high risk partial' do
             post :step_3, affordability: {
-                            people_attributes: {
-                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "100"}
-                            },
-                            outgoings: {}
-                          }
+              people_attributes: {
+                '0' => {
+                  annual_income: '100000',
+                  extra_income: '10000',
+                  monthly_net_income: '100'
+                }
+              },
+              outgoings: {}
+            }
 
             expect(response).to render_template('_high_budget_affect')
           end
@@ -98,11 +128,15 @@ module MortgageCalculator
         context 'when at medium risk' do
           it 'renders medium risk partial' do
             post :step_3, affordability: {
-                            people_attributes: {
-                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "4000"}
-                            },
-                            outgoings: {}
-                          }
+              people_attributes: {
+                '0' => {
+                  annual_income: '100000',
+                  extra_income: '10000',
+                  monthly_net_income: '4000'
+                }
+              },
+              outgoings: {}
+            }
 
             expect(response).to render_template('_medium_budget_affect')
           end
@@ -111,11 +145,15 @@ module MortgageCalculator
         context 'when at low risk' do
           it 'renders low risk partial' do
             post :step_3, affordability: {
-                            people_attributes: {
-                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "8000"}
-                            },
-                            outgoings: {}
-                          }
+              people_attributes: {
+                '0' => {
+                  annual_income: '100000',
+                  extra_income: '10000',
+                  monthly_net_income: '8000'
+                }
+              },
+              outgoings: {}
+            }
 
             expect(response).to render_template('_low_budget_affect')
           end
@@ -135,11 +173,15 @@ module MortgageCalculator
         context 'when at high risk' do
           before do
             post :step_3, affordability: {
-                            people_attributes: {
-                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "100"}
-                            },
-                            outgoings: {}
-                          }
+              people_attributes: {
+                '0' => {
+                  annual_income: '100000',
+                  extra_income: '10000',
+                  monthly_net_income: '100'
+                }
+              },
+              outgoings: {}
+            }
           end
 
           it 'renders high risk next steps partial' do
@@ -152,11 +194,15 @@ module MortgageCalculator
         context 'when at medium risk' do
           before do
             post :step_3, affordability: {
-                            people_attributes: {
-                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "4000"}
-                            },
-                            outgoings: {}
-                          }
+              people_attributes: {
+                '0' => {
+                  annual_income: '100000',
+                  extra_income: '10000',
+                  monthly_net_income: '4000'
+                }
+              },
+              outgoings: {}
+            }
           end
 
           it 'renders medium risk next steps partial' do
@@ -169,11 +215,15 @@ module MortgageCalculator
         context 'when at low risk' do
           before do
             post :step_3, affordability: {
-                            people_attributes: {
-                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "8000"}
-                            },
-                            outgoings: {}
-                          }
+              people_attributes: {
+                '0' => {
+                  annual_income: '100000',
+                  extra_income: '10000',
+                  monthly_net_income: '8000'
+                }
+              },
+              outgoings: {}
+            }
           end
 
           it 'renders low risk next steps partial' do
@@ -183,7 +233,7 @@ module MortgageCalculator
           end
         end
 
-        context 'when tool is not completed and no risk level has been determined' do
+        context 'when tool has not been completed' do
           it 'renders default next steps partial' do
             get :next_steps
 

--- a/spec/controllers/affordabilities_controller_spec.rb
+++ b/spec/controllers/affordabilities_controller_spec.rb
@@ -182,6 +182,14 @@ module MortgageCalculator
             expect(response).to render_template('_low_risk_next_steps')
           end
         end
+
+        context 'when tool is not completed and no risk level has been determined' do
+          it 'renders default next steps partial' do
+            get :next_steps
+
+            expect(response).to render_template('_default_risk_next_steps')
+          end
+        end
       end
     end
   end

--- a/spec/controllers/affordabilities_controller_spec.rb
+++ b/spec/controllers/affordabilities_controller_spec.rb
@@ -128,7 +128,61 @@ module MortgageCalculator
         get :next_steps
         expect(response).to be_success
       end
+
+      describe 'shows different content dependent on risk level' do
+        render_views
+
+        context 'when at high risk' do
+          before do
+            post :step_3, affordability: {
+                            people_attributes: {
+                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "100"}
+                            },
+                            outgoings: {}
+                          }
+          end
+
+          it 'renders high risk next steps partial' do
+            get :next_steps
+
+            expect(response).to render_template('_high_risk_next_steps')
+          end
+        end
+
+        context 'when at medium risk' do
+          before do
+            post :step_3, affordability: {
+                            people_attributes: {
+                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "4000"}
+                            },
+                            outgoings: {}
+                          }
+          end
+
+          it 'renders medium risk next steps partial' do
+            get :next_steps
+
+            expect(response).to render_template('_medium_risk_next_steps')
+          end
+        end
+
+        context 'when at low risk' do
+          before do
+            post :step_3, affordability: {
+                            people_attributes: {
+                              "0"=>{annual_income: "100000", extra_income: "10000", monthly_net_income: "8000"}
+                            },
+                            outgoings: {}
+                          }
+          end
+
+          it 'renders low risk next steps partial' do
+            get :next_steps
+
+            expect(response).to render_template('_low_risk_next_steps')
+          end
+        end
+      end
     end
   end
 end
-

--- a/spec/controllers/affordabilities_controller_spec.rb
+++ b/spec/controllers/affordabilities_controller_spec.rb
@@ -121,7 +121,9 @@ module MortgageCalculator
               outgoings: {}
             }
 
-            expect(response).to render_template('_high_budget_affect')
+            expect(response.body).to include(
+              I18n.t('affordability.budget_affect.high.percentage_html')
+            )
           end
         end
 
@@ -138,7 +140,9 @@ module MortgageCalculator
               outgoings: {}
             }
 
-            expect(response).to render_template('_medium_budget_affect')
+            expect(response.body).to include(
+              I18n.t('affordability.budget_affect.medium.percentage_html')
+            )
           end
         end
 
@@ -155,7 +159,9 @@ module MortgageCalculator
               outgoings: {}
             }
 
-            expect(response).to render_template('_low_budget_affect')
+            expect(response.body).to include(
+              I18n.t('affordability.budget_affect.low.percentage_html')
+            )
           end
         end
       end
@@ -184,10 +190,12 @@ module MortgageCalculator
             }
           end
 
-          it 'renders high risk next steps partial' do
+          it 'displays high risk next steps content' do
             get :next_steps
 
-            expect(response).to render_template('_high_risk_next_steps')
+            expect(response.body).to include(
+              I18n.t('affordability.next_steps.high.title')
+            )
           end
         end
 
@@ -205,10 +213,12 @@ module MortgageCalculator
             }
           end
 
-          it 'renders medium risk next steps partial' do
+          it 'displays medium risk next steps content' do
             get :next_steps
 
-            expect(response).to render_template('_medium_risk_next_steps')
+            expect(response.body).to include(
+              I18n.t('affordability.next_steps.medium.title')
+            )
           end
         end
 
@@ -226,18 +236,22 @@ module MortgageCalculator
             }
           end
 
-          it 'renders low risk next steps partial' do
+          it 'displays low risk next steps content' do
             get :next_steps
 
-            expect(response).to render_template('_low_risk_next_steps')
+            expect(response.body).to include(
+              I18n.t('affordability.next_steps.low.title')
+            )
           end
         end
 
         context 'when tool has not been completed' do
-          it 'renders default next steps partial' do
+          it 'displays default next steps content' do
             get :next_steps
 
-            expect(response).to render_template('_default_risk_next_steps')
+            expect(response.body).to include(
+              I18n.t('affordability.next_steps.default.title')
+            )
           end
         end
       end


### PR DESCRIPTION
#### TP Link
[8648](https://moneyadviceservice.tpondemand.com/entity/8648-update-mortgage-affordability-calculator-next-steps)
#### Summary
Adds different 'next steps' content to be shown depending on the risk level assigned by the tool (low, medium or high risk).
Also adds default content to be shown if someone lands directly on the 'next steps' page without having completed the tool.

#### *Screenshots of updated content*

##### Low risk
![low](https://user-images.githubusercontent.com/11137272/35813311-30447e4c-0a8b-11e8-93f0-4e1a9ac020e4.png)
##### Medium risk
![medium](https://user-images.githubusercontent.com/11137272/35813331-3e6f3034-0a8b-11e8-8712-fbc74ad5a610.png)
##### High risk
![high](https://user-images.githubusercontent.com/11137272/35813342-4549e700-0a8b-11e8-88b7-6d6c1b7dc008.png)
##### Default
![default](https://user-images.githubusercontent.com/11137272/35813362-53fdc1f4-0a8b-11e8-9dba-f59a891ccc64.png)
