### PR TITLE
[DEV APPROVED] - Remove factory-girl-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ group :test do
   gem 'capybara'
   gem 'coffee-rails'
   gem 'cucumber', '~> 3.0.1'
-  gem 'factory_girl_rails'
   gem 'mas-templating'
   gem 'rspec-its'
   gem 'rspec_junit_formatter'


### PR DESCRIPTION
FactoryGirl has been replaced by FactoryBot. None of the specs in this repo use FactoryGirl so rather than upgrade to FactoryBot to address the deprecation warnings I have removed it. 