### PR TITLE
[DEV APPROVED] 8939: Fixes broken next steps link and broken cy route

### DIFF
--- a/app/views/mortgage_calculator/affordabilities/_low_risk_next_steps.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_low_risk_next_steps.html.erb
@@ -26,7 +26,7 @@
     <%= t("affordability.next_steps.low.tip_3.info_html",
           steps: link_to(
             t("affordability.next_steps.low.tip_3.url_text"),
-            t("affordability.low.next_steps.tip_3.url"),
+            t("affordability.next_steps.low.tip_3.url"),
             target: "_blank",
             rel: no_follow?
           )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ MortgageCalculator::Engine.routes.draw do
   resource :affordability, path: "cyfrifiannell-fforddiadwyedd-morgais", as: 'affordability_cy' do
     get '/', to: "affordabilities#step_1"
     collection do
-      get 'step_1', path: "step-1"
+      match 'step_1', path: "step-1", via: [:get, :post]
       match 'step_2', path: "step-2", via: [:get, :post]
       match 'step_3', path: "step-3", via: [:get, :post]
       get 'next_steps'

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 2
     MINOR = 4
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/spec/routing/affordability_routing_spec.rb
+++ b/spec/routing/affordability_routing_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe MortgageCalculator::AffordabilitiesController, type: :routing do
+  routes { MortgageCalculator::Engine.routes }
+
+  describe 'GET /mortgage-affordability-calculator/step-1' do
+    it 'routes to first step in English' do
+      expect(get: '/mortgage-affordability-calculator/step-1').to route_to(
+        controller: 'mortgage_calculator/affordabilities',
+        action: 'step_1'
+      )
+    end
+  end
+
+  describe 'GET /cyfrifiannell-fforddiadwyedd-morgais/step-1' do
+    it 'routes to first step in Welsh' do
+      expect(get: '/cyfrifiannell-fforddiadwyedd-morgais/step-1').to route_to(
+        controller: 'mortgage_calculator/affordabilities',
+        action: 'step_1'
+      )
+    end
+  end
+
+  describe 'POST /mortgage-affordability-calculator/step-1' do
+    it 'routes to first step in English' do
+      expect(post: '/mortgage-affordability-calculator/step-1').to route_to(
+        controller: 'mortgage_calculator/affordabilities',
+        action: 'step_1'
+      )
+    end
+  end
+
+  describe 'POST /cyfrifiannell-fforddiadwyedd-morgais/step-1' do
+    it 'routes to first step in Welsh' do
+      expect(post: '/cyfrifiannell-fforddiadwyedd-morgais/step-1').to route_to(
+        controller: 'mortgage_calculator/affordabilities',
+        action: 'step_1'
+      )
+    end
+  end
+end


### PR DESCRIPTION
[TP 8939](https://moneyadviceservice.tpondemand.com/entity/8939-mortgage-affordability-calculator-fix-the-link)

#### Summary

Includes 2 small fixes for the Mortgage Affordability Calculator:

* Next steps content was updated in [8648](https://moneyadviceservice.tpondemand.com/entity/8648-update-mortgage-affordability-calculator-next-steps), however there was an error in the partial for low risk content which meant one of the links was broken. The error is corrected here.

* There's currently a broken route to post to the Welsh version of step 1 of the calculator which results in a 500 when submitting the form. The `en` route was previously updated to include `post` but it looks as though the `cy` route was missed. The `cy` route is updated here to match the `en` version.