### PR TITLE
[DEV APPROVED] 8798 create land and buildings transaction tax calculator PART 2

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_elsewhere.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_elsewhere.scss
@@ -1,0 +1,51 @@
+.elsewhere__container {
+  background: $color-grey-pale;
+}
+.elsewhere__item {
+  @include column(12);
+  margin-bottom: $baseline-unit*1;
+  position: relative;
+  padding-top: $baseline-unit*3;
+  padding-bottom: $baseline-unit*2;
+  &:hover &,
+  &:focus & {
+    text-decoration: none;
+  }
+  @include respond-to($mq-s) {
+    &:nth-child(2) {
+      @include push(0)
+    }
+  }
+
+  @include respond-to($mq-m) {
+    @include column(6);
+    &:nth-child(2) {
+      @include push(0)
+    }
+  }
+
+  @include respond-to($mq-l) {
+    @include column(5);
+    border-top: 0;
+    margin-bottom: 0;
+    &:nth-child(2) {
+      @include push
+    }
+    margin: $baseline-unit*4;
+  }
+}
+.elsewhere__item-content {
+  margin-right: 60px;
+}
+
+.elsewhere__arrow {
+  position: absolute;
+  top:0;
+  right:0;
+  background-color: $color-button-primary;
+  border-radius: 50px;
+  height: 50px;
+  top: 30%;
+  width: 50px;
+  padding: 10px;
+}

--- a/app/controllers/mortgage_calculator/land_and_buildings_transaction_taxes_controller.rb
+++ b/app/controllers/mortgage_calculator/land_and_buildings_transaction_taxes_controller.rb
@@ -1,0 +1,36 @@
+module MortgageCalculator
+  class LandAndBuildingsTransactionTaxesController < ::MortgageCalculator::ApplicationController
+    CALCULATOR = MortgageCalculator::LandAndBuildingsTransactionTax
+    before_action :set_rates
+    def show
+      @lbtt = CALCULATOR.new
+    end
+
+    def create
+      @lbtt = CALCULATOR.new(
+        params.require(:land_and_buildings_transaction_tax)
+          .permit(:price, :buyer_type)
+          .symbolize_keys
+      )
+      unless @lbtt.valid?
+        render :show
+      end
+    end
+
+    private
+
+    def set_rates
+      @rates = CALCULATOR.banding_for(
+        CALCULATOR::STANDARD_BANDS
+      )
+    end
+
+    def category_id
+      'buying-a-home'
+    end
+
+    def tool_name
+      I18n.translate('land_and_buildings_transaction_tax.tool_name')
+    end
+  end
+end

--- a/app/helpers/mortgage_calculator/land_and_buildings_transaction_taxes_helper.rb
+++ b/app/helpers/mortgage_calculator/land_and_buildings_transaction_taxes_helper.rb
@@ -1,0 +1,41 @@
+module MortgageCalculator
+  module LandAndBuildingsTransactionTaxesHelper
+    def band(num1, num2)
+      num1 = num1.ceil
+      return maximum_band(num1 - 1) if num2.nil?
+      "#{formatted_currency(num1)} - #{formatted_currency(num2)}"
+    end
+
+    def second_home_rate(rate)
+      rate + LandAndBuildingsTransactionTax::SECOND_HOME_ADDITIONAL_TAX
+    end
+
+    def second_home_threshold
+      formatted_currency(
+        MortgageCalculator::LandAndBuildingsTransactionTax::SECOND_HOME_THRESHOLD
+      )
+    end
+
+    def calculator_config_json
+      calculator = MortgageCalculator::StampDuty
+      {
+        standard: calculator::STANDARD_BANDS,
+        second_home_tax_rate: calculator::SECOND_HOME_ADDITIONAL_TAX,
+        second_home_threshold: calculator::SECOND_HOME_THRESHOLD
+      }.to_json
+    end
+
+    private
+
+    def maximum_band(num)
+      I18n.t(
+        'land_and_buildings_transaction_tax.table.max',
+        value: formatted_currency(num)
+      )
+    end
+
+    def formatted_currency(num)
+      number_to_currency(num, precision: 0)
+    end
+  end
+end

--- a/app/models/mortgage_calculator/land_and_buildings_transaction_tax.rb
+++ b/app/models/mortgage_calculator/land_and_buildings_transaction_tax.rb
@@ -1,0 +1,21 @@
+module MortgageCalculator
+  class LandAndBuildingsTransactionTax < TaxCalculator
+    def self.i18n_scope
+      'land_and_buildings_transaction_tax.activemodel'
+    end
+
+    STANDARD_BANDS = [
+      { threshold: 145_000, rate: 0 },
+      { threshold: 250_000, rate: 2 },
+      { threshold: 325_000, rate: 5 },
+      { threshold: 750_000, rate: 10 },
+      { threshold: nil, rate: 12 }
+    ].freeze
+
+    protected
+
+    def bands_to_use
+      STANDARD_BANDS
+    end
+  end
+end

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_bands_table.html.erb
@@ -1,0 +1,18 @@
+<table class="mortgagecalc__table stamp-duty__table">
+  <thead>
+    <tr>
+      <th class="mortgagecalc__table__price"><%= I18n.t("land_and_buildings_transaction_tax.table.property_price_header") %></th>
+      <th class="mortgagecalc__table__rate"><%= I18n.t("land_and_buildings_transaction_tax.table.rate_header") %></th>
+      <th class="mortgagecalc__table__extra"><%= I18n.t("land_and_buildings_transaction_tax.table.extra_rate_header") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @rates.each do |rate| %>
+      <tr>
+        <td class="mortgagecalc__table__price"><%= band(rate[:start], rate[:end]) %></td>
+        <td class="mortgagecalc__table__rate"><%= rate[:rate] %>%</td>
+        <td class="mortgagecalc__table__extra"><%= second_home_rate(rate[:rate]) %>%</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_elsewhere.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_elsewhere.html.erb
@@ -1,0 +1,19 @@
+<div class="l-constrained elsewhere__container">
+  <a class="elsewhere__item promo__link" href="<%= t('land_and_buildings_transaction_tax.elsewhere.england_ni.link') %>">
+    <div class="elsewhere__item-content">
+    <h3 class="promo__heading"><%= t('land_and_buildings_transaction_tax.elsewhere.england_ni.title') %></h3>
+    <p class="promo__content"><%= t('land_and_buildings_transaction_tax.elsewhere.england_ni.body') %></p></div>
+    <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right elsewhere__arrow" focusable="false">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right"></use>
+    </svg>
+  </a>
+  <a class="elsewhere__item promo__link" href="<%= t('land_and_buildings_transaction_tax.elsewhere.wales.link') %>">
+    <div class="elsewhere__item-content">
+    <h3 class="promo__heading"><%= t('land_and_buildings_transaction_tax.elsewhere.wales.title') %></h3>
+    <p class="promo__content"><%= t('land_and_buildings_transaction_tax.elsewhere.wales.body') %></p>
+    </div>
+    <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right elsewhere__arrow" focusable="false">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right"></use>
+    </svg>
+  </a>
+</div>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_form_step1.html.erb
@@ -1,0 +1,55 @@
+<%= form_for @lbtt, url: land_and_buildings_transaction_tax_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_one stamp-duty__step-one', novalidate: '' } do |f| %>
+
+  <%= f.label :buyer_type, class: 'stamp-duty__buyer-type' do %>
+    <%= t('land_and_buildings_transaction_tax.select.label') %>
+    <%= f.select(:buyer_type, [
+      [t('land_and_buildings_transaction_tax.select.option_prompt'), ''],
+      [t('land_and_buildings_transaction_tax.select.option_isNextHome'), 'isNextHome'],
+      [t('land_and_buildings_transaction_tax.select.option_isSecondHome'), 'isSecondHome']
+      ], {}, {'ng-model' => 'stampDuty.buyerType'}
+    )%>
+    <span data-dough-component="PopupTip">
+      <%= popup_tip_trigger options: {
+        text: t('land_and_buildings_transaction_tax.tooltip_show')
+      } %>
+      <%= popup_tip_content options: {
+        text: t('land_and_buildings_transaction_tax.select.tooltip_html'),
+        classname: 'details__helper',
+        tooltip_hide: t('land_and_buildings_transaction_tax.tooltip_hide')
+      } %>
+    </span>
+  <% end %>
+
+  <div class="stamp-duty__form form__item">
+    <%= f.label :price, class: "stamp-duty__input-description" %>
+    <div class="visually-hidden" id="mc_accessibility_describe_price"><%= t 'land_and_buildings_transaction_tax.describe_price_field' %></div>
+
+    <span class="stamp-duty__input-wrapper stamp-duty__input-wrapper--inline">
+      <span class="stamp-duty__input--unit">£</span>
+      <%= f.text_field :price,
+      :value => @lbtt.price_formatted,
+      "autofocus" => '',
+      "ng-model" => "stampDuty.propertyPrice",
+      "placeholder" => "0",
+      "currency" => '',
+      "data-m-dec" =>"0",
+      "pattern" => '\d*',
+      "class" => 'stamp-duty__input' %>
+    </span>
+
+    <%= f.submit I18n.t("land_and_buildings_transaction_tax.next"),
+    class: "button button--primary stamp-duty__submit",
+      'ng-click' => 'navigateAndFocus($event)',
+      'ng-disabled' => '!stampDuty.propertyPrice || !stampDuty.buyerType',
+      'analytics-category' => 'Stamp Duty Calculator',
+      'analytics-action' => 'Completion',
+      'analytics-label' => 'Click',
+      'analytics' => '',
+      'analytics-on' => 'click'
+    %>
+  </div>
+<% end %>
+<hr />
+
+<h2><%= t('land_and_buildings_transaction_tax.elsewhere.title') %></h2>
+<p><%= t('land_and_buildings_transaction_tax.elsewhere.body') %></p>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_form_step2.html.erb
@@ -1,0 +1,83 @@
+<div class="stamp-duty__calculator-column">
+  <%= form_for @lbtt, url: land_and_buildings_transaction_tax_path, html: { id: 'update_stamp_duty', name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
+    <div class="form__item stamp-duty__form">
+      <%= f.label :price, class: 'stamp-duty__input-description' %>
+      <div class="visually-hidden"
+            id="mc_accessibility_describe_price">
+        <%= t 'land_and_buildings_transaction_tax.describe_price_field' %>
+      </div>
+
+      <span class="stamp-duty__input-wrapper">
+        <span class="stamp-duty__input--unit">£</span>
+        <%= f.text_field :price,
+                         :value => @lbtt.price_formatted,
+                         class: 'stamp-duty__input dynamic-slider-property',
+                         "ng-model" => "stampDuty.propertyPrice",
+                         "placeholder" => "0.00",
+                         "currency" => '',
+                         "data-m-dec" => "0",
+                         "analytics" => "",
+                         "analytics-on" => "change",
+                         "analytics-category" => "Stamp Duty Calculator",
+                         "analytics-action" => "Refinement",
+                         "analytics-label" => "Price",
+                         "pattern" => '\d*',
+                         "aria-describedby" => 'mc_accessibility_describe_price',
+                         "autoselect" => ""
+                         %>
+      </span>
+
+    </div>
+    <%= f.hidden_field :buyer_type %>
+
+    <div class="slider"
+          ui-slider
+          dynamic-for='dynamic-slider-property'
+          ng-model="stampDuty.propertyPrice"
+          analytics-category="Stamp Duty"
+          analytics-action="Refinement"
+          analytics-label="Price"
+          aria-hidden="true">
+    </div>
+
+    <div class="hide-with-js">
+      <p><br><%= f.submit I18n.t("land_and_buildings_transaction_tax.recalculate"),
+                          'class' => 'button',
+                          'wz-next' => '' %></p>
+    </div>
+
+  <% end %>
+
+  <%= render 'stamp_duty_to_pay_panel' if @lbtt.valid? %>
+
+  <div class="">
+    <h2 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h2>
+    <p><%= link_to t('land_and_buildings_transaction_tax.next_steps.have_you_tried.mortgage_calculator'),
+                   full_mortgage_calculator_url,
+                   class: "button button--primary mortgagecalc__spread stamp-duty__button",
+                   target: "_blank",
+                   rel: no_follow? %>
+
+      <%= link_to t('land_and_buildings_transaction_tax.next_steps.have_you_tried.mortgage_affordability_calculator'),
+                   full_mortgage_affordability_calculator_url,
+                   class: "button button--primary mortgagecalc__spread stamp-duty__button",
+                   target: "_blank",
+                   rel: no_follow? %></p>
+  </div>
+</div>
+
+<div class="stamp-duty__info-column">
+  <div class="callout callout--tip">
+    <span class="callout__icon" aria-hidden="true">?</span>
+    <h2 class="stamp-duty__info-subheading callout__heading"><%= I18n.t("land_and_buildings_transaction_tax.next_steps.learn_more.title") %></h2>
+    <p class="stamp-duty__info-tip"><%= I18n.t("land_and_buildings_transaction_tax.next_steps.learn_more.tip_1") %></p>
+    <p><a class="stamp-duty__info-tip-link" href="<%= I18n.t("land_and_buildings_transaction_tax.next_steps.learn_more.link_1.url") %>"><%= I18n.t("land_and_buildings_transaction_tax.next_steps.learn_more.link_1.title") %></a>
+  </div>
+
+  <h2 class="mortgagecalc__subheading"><%= I18n.t("land_and_buildings_transaction_tax.next_steps.find_out_more.title") %>:</h2>
+  <ul>
+    <% I18n.t("land_and_buildings_transaction_tax.next_steps.find_out_more.tips").each do |tip| %>
+      <li class="stamp-duty__info-tip-link"><%= link_to tip[:copy_html], tip[:url], target: "_blank", rel: no_follow? %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_next_home_buyer_explanation.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_next_home_buyer_explanation.html.erb
@@ -1,0 +1,6 @@
+<p><%= I18n.t("land_and_buildings_transaction_tax.how_calculated") %></p>
+<p><%= I18n.t("land_and_buildings_transaction_tax.how_calculated_additional") %></p>
+
+<%= render 'bands_table', rates: @rates %>
+
+<p><%= I18n.t('land_and_buildings_transaction_tax.how_calculated_extra', amount: second_home_threshold) %></p>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_seo_links.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_seo_links.html.erb
@@ -1,0 +1,11 @@
+<div class="mortgagecalc__panel">
+  <h2 class="mortgagecalc__heading"><%= t("affordability.next_steps.have_you_tried.title") %></h2>
+
+  <p><%= link_to I18n.t('land_and_buildings_transaction_tax.next_steps.have_you_tried.mortgage_calculator'),
+                   full_mortgage_calculator_url,
+                   target: "_blank" %></p>
+
+  <p><%= link_to I18n.t('land_and_buildings_transaction_tax.next_steps.have_you_tried.mortgage_affordability_calculator'),
+                   full_mortgage_affordability_calculator_url,
+                   target: "_blank" %></p>
+</div>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_stamp_duty_tip.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_stamp_duty_tip.html.erb
@@ -1,0 +1,13 @@
+<div class="mortgagecalc__panel--full">
+  <div ng-show="expandedStampDutyInformation" class="mortgagecalc__tip">
+    <div class="stamp-duty stamp-duty__calculation-explanation">
+        <div ng-hide="js" class="stamp-duty__explanation-nexthome ng-hide is-active">
+          <%= render 'next_home_buyer_explanation' %>
+        </div>
+
+      <div class="rendered-from-js stamp-duty__explanation-nexthome">
+        <%= render 'next_home_buyer_explanation' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
@@ -1,0 +1,58 @@
+<div class="stamp-duty__results">
+  <div class="stamp-duty__results-heading" aria-live="polite" aria-atomic="true">
+    <div ng-hide="js">
+      <% key = @lbtt.second_home? ? 'second_title' : 'title' %>
+      <%= I18n.t("land_and_buildings_transaction_tax.results.#{key}") %>
+    </div>
+    <div class="hidden-unless-js">
+      <span ng-if="stampDuty.isSecondHome">
+        <%= I18n.t('land_and_buildings_transaction_tax.results.second_title') %>
+      </span>
+      <span ng-if="!stampDuty.isSecondHome">
+        <%= I18n.t('land_and_buildings_transaction_tax.results.title') %>
+      </span>
+    </div>
+
+    <span ng-hide="js">
+      <%= number_to_currency @lbtt.tax_due_formatted %>
+    </span>
+    <span class="rendered-from-js">
+      {{ stampDuty.cost() | customCurrency:"£" }}
+    </span>
+  </div>
+
+  <p ng-hide="js" class="stamp-duty__results-tax-rate ng-hide">
+    <%= I18n.t('land_and_buildings_transaction_tax.results.sentence',
+              percentage: number_to_percentage(
+                @lbtt.percentage_tax, precision: 2
+              )
+        )
+    %>
+  </p>
+
+  <p class="rendered-from-js stamp-duty__results-tax-rate">
+    <%= I18n.t('land_and_buildings_transaction_tax.results.sentence_prefix') %>
+    {{ stampDuty.percentageTax() | number: 2 }}
+    <%= I18n.t('land_and_buildings_transaction_tax.results.sentence_suffix') %>
+  </p>
+
+  <p class="rendered-from-js stamp-duty__FTB_conditional">
+    <%= I18n.t('land_and_buildings_transaction_tax.results.FTB_conditional', amount: 0) %>
+  </p>
+
+  <div>
+    <a href="#"
+       class="rendered-from-js
+              expander expander--nudge
+              stamp-duty__how-calculated-toggle"
+                ng-class="{ 'expander--expanded' : expandedStampDutyInformation }"
+                ng-click="toggleStampDutyExpanded($event)"
+                affects-height="click">
+      <%= I18n.t('land_and_buildings_transaction_tax.how_calculated_toggle') %>
+      <span class="visually-hidden">
+        <%= I18n.t('land_and_buildings_transaction_tax.results.click_to_expand') %>
+      </span>
+    </a>
+    <%= render 'stamp_duty_tip' %>
+  </div>
+</div>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/create.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/create.html.erb
@@ -1,0 +1,8 @@
+<div class="stamp-duty">
+  <div class="stamp-duty__container">
+    <h1 class="stamp-duty__heading">
+      <%= I18n.t('land_and_buildings_transaction_tax.heading_results') %>
+    </h1>
+    <%= render 'form_step2' %>
+  </div>
+</div>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/show.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for(:head) do %>
+  <script>
+   window.calculator_config = <%= raw calculator_config_json %>;
+  </script>
+<% end %>
+
+<div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
+  <% @lbtt.errors.full_messages.each do |message| %>
+    <span style="color:red;"><%= message %></span>
+  <% end %>
+  <div wizard on-finish="finishedWizard()" hide-indicators='true'>
+    <div wz-step class="ng-hide">
+      <div class="stamp-duty__container">
+        <h1 class="stamp-duty__heading"><%= I18n.t('land_and_buildings_transaction_tax.heading') %></h1>
+        <h2 class="intro stamp-duty__subheading"><%= I18n.t('land_and_buildings_transaction_tax.title') %></h2>
+        <%= render 'form_step1' %>
+      </div>
+      <%= render 'elsewhere' %>
+    </div>
+
+    <div wz-step class="ng-hide">
+      <div class="rendered-from-js">
+        <div class="stamp-duty__container">
+          <h1 class="stamp-duty__heading"><%= I18n.t('land_and_buildings_transaction_tax.heading_results') %></h1>
+          <%= render 'form_step2' %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/land_and_buildings_transaction_tax.cy.yml
+++ b/config/locales/land_and_buildings_transaction_tax.cy.yml
@@ -1,0 +1,73 @@
+cy:
+  land_and_buildings_transaction_tax:
+    meta:
+      title: "Cyfrifiannell Treth Trafodion Tir ac Adeiladau"
+      description: "Cyfrifwch y Dreth Trafodion Tir ac Adeiladau ar eich eiddo preswyl yn yr Alban"
+      canonical_url: "https://www.moneyadviceservice.org.uk/cy/tools/prynu-ty/cyfrifiannell-treth-trafodion-tir-ac-adeiladau"
+    tooltip_show: sioe help
+    tooltip_hide: cuddio cymorth
+    tool_name: "cyfrifiannell-treth-trafodion-tir-ac-adeiladau"
+    heading: "Cyfrifiannell Treth Trafodion Tir ac Adeiladau"
+    heading_results: "Cyfrifiannell Treth Trafodion Tir ac Adeiladau - Eich canlyniadau"
+    title: "Cyfrifwch y Dreth Trafodion Tir ac Adeiladau ar eich eiddo preswyl yn yr Alban"
+    next: "Nesaf"
+    select:
+      label: "Rwy'n"
+      option_prompt: "dewiswch opsiwn"
+      option_isNextHome: "prynu fy nghartref nesaf"
+      option_isSecondHome: "prynu eiddo atodol neu eiddo prynu-i-osod"
+      tooltip_html: "Bydd unrhyw un sy’n prynu cartref ychwanegol gan gynnwys eiddo prynu i osod dros £40,000 mewn gwerth yn gorfod talu ffi ychwanegol o 3% ar ben pob band Treth Trafodiadau Tir ac Adeiladau."
+    recalculate: Ailgyfrifo
+    how_calculated_toggle: "Sut y cyfrifir hyn?"
+    elsewhere:
+      title: "Prynu yng Nghymru, Lloegr neu Ogledd Iwerddon?"
+      body: "Os ydych chi'n prynu yn unrhyw un o'r gwledydd hyn, yna defnyddiwch y gyfrifiannell briodol i gyfrifo faint fyddwch chi'n ei dalu:"
+      england_ni:
+        title: "Cyfrifwch Dreth Stamp yng Nghymru, Lloegr neu Ogledd Iwerddon"
+        body: "Rhaid talu Treth Stamp ar eiddo yn Lloegr a Gogledd Iwerddon o hyd"
+        link: "/cy/tools/prynu-ty/cyfrifiannell-treth-stamp"
+      wales:
+        title: "Cyfrifwch Dreth Trafodiadau Tir ar gyfer Cymru"
+        body: "Ym mis Ebrill 2018 bydd Treth Trafodiadau Tir (LTT) yn disodli Treth Stamp yng Nghymru. Bydd gennym gyfrifiannell ar gyfer hyn ym mis Ebrill ond am y tro defnyddiwch y Gyfrifiannell Treth Stamp."
+        link: "/cy/tools/prynu-ty/cyfrifiannell-treth-stamp"
+    how_calculated_toggle: "Sut y cyfrifir hyn?"
+    how_calculated: "Telir Treth Trafodion Tir ac Adeiladau (LBTT) ar gyfraddau gwahanol, yn ddibynnol ar y band mae’r pris prynu ynddo. Er enghraifft, ni fyddai rhywun yn prynu eiddo am £280,000 yn talu treth ar werth yr eiddo hyd at £145,000, 2% o dreth ar werth yr eiddo rhwng £145,001 a £250,000 a 5% ar werth yr eiddo rhwng £250,001 a £280,000. Yn yr achos hwn, byddai cyfanswm yr atebolrwydd treth ar gyfer Treth Trafodion Tir ac Adeiladau (LBTT) yn £3,600 gan roi cyfradd dreth effeithiol o 1.29% (cyfartaledd cyfradd canrannol y dreth a dalwyd)."
+    how_calculated_additional: "Bydd unrhyw un sy’n prynu ail gartref, gan gynnwys eiddo prynu-i-osod, yn talu 3% ychwanegol ar ben y band cyfradd safonol. Yn yr enghraifft hon, byddai hynny'n cynrychioli £8,400 ychwanegol, sy'n golygu y byddai cyfanswm y dreth stamp yn £12,000 gan roi cyfradd treth effeithiol o 4.29%."
+    how_calculated_extra: "* Nid yw eiddo dan %{amount} yn destun yr Atodiad Annedd Atodol ar gyfer ail gartref"
+    describe_price_field: "Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn."
+    activemodel:
+      attributes:
+        mortgage_calculator/land_and_buildings_transaction_tax:
+          price: "Pris eiddo:"
+    results:
+      title: "Y Treth Trafodion Tir ac Adeiladau i'w thalu yw"
+      second_title: "Y Treth Trafodion Tir ac Adeiladau i'w thalu yw"
+      sentence: "Y gyfradd dreth effeithiol yw %{percentage}"
+      sentence_prefix: "Y gyfradd dreth effeithiol yw"
+      sentence_suffix: "%"
+      click_to_expand: Cliciwch i ehangu
+    table:
+      property_price_header: "Pris prynu’r eiddo"
+      rate_header: "Cyfradd Treth Trafodion Tir ac Adeiladau (LBTT)"
+      extra_rate_header: "Atodiad Prynu-i-osod / Annedd Atodol (ADS)*"
+      max: "%{value}+"
+    next_steps:
+      learn_more:
+        title: "A wyddech chi?"
+        tip_1: "Rhaid i chi dalu Treth Trafodiadau Tir ac Adeiladau (LBTT) cyn pen 30 diwrnod ar ôl prynu eiddo. Os ydych yn defnyddio cyfreithiwr i gwblhau’r trawsgludo, bydd fel arfer yn trefnu’r taliad ar eich rhan."
+        link_1:
+          title: "Treth Trafodiadau Tir ac Adeiladau (LBTT) - popeth sydd angen i chi ei wybod"
+          url: "/cy/articles/treth-trafodiadau-tir-ac-adeiladau-popeth-y-mae-angen-i-chi-ei-wybod/"
+      find_out_more:
+        title: "Darganfyddwch fwy"
+        tips:
+          - copy_html: "Costau ymlaen llaw prynu cartref"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
+          - copy_html: "Ffioedd a chostau morgais"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/cipolwg-ar-ffioedd-a-chostau-syn-gysylltiedig-a-morgeisi"
+          - copy_html: "Costau diwrnod symud"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/cynllunio-ar-gyfer-cost-diwrnod-symud"
+      have_you_tried:
+        title: 'Rhowch gynnig ar?'
+        mortgage_calculator: "Cyfrifiannell morgais"
+        mortgage_affordability_calculator: "Cyfrifiannell fforddiadwyedd"

--- a/config/locales/land_and_buildings_transaction_tax.en.yml
+++ b/config/locales/land_and_buildings_transaction_tax.en.yml
@@ -1,0 +1,72 @@
+en:
+  land_and_buildings_transaction_tax:
+    meta:
+      title: "Land and Buildings Transaction Tax calculator"
+      description: "Calculate the Land and Buildings Transaction Tax on your residential property in Scotland"
+      canonical_url: "https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-and-buildings-transaction-tax-calculator"
+    tooltip_show: show help
+    tooltip_hide: hide help
+    tool_name: "land-and-buildings-transaction-tax-calculator"
+    heading: "Land and Buildings Transaction Tax (LBTT) calculator"
+    heading_results: "Land and Buildings Transaction Tax (LBTT) calculator - Your Results"
+    title: "Calculate the Land and Buildings Transaction Tax on your residential property in Scotland"
+    next: Next
+    select:
+      label: I am
+      option_prompt: please select an option
+      option_isNextHome: buying my next home
+      option_isSecondHome: buying an additional or buy-to-let property
+      tooltip_html: "Anyone purchasing an additional home including buy to let properties over the value of £40,000 will have to pay an extra 3% surcharge on top of each Land and Buildings Transaction Tax band"
+    recalculate: Recalculate
+    elsewhere:
+      title: "Buying in England, Northern Ireland or Wales?"
+      body: "If you are buying in any of these countries then use the appropriate calculator to work out how much you will pay"
+      england_ni:
+        title: Calculate Stamp Duty in England or Northern Ireland
+        body: Properties in England and Northen Ireland are still subject to Stamp Duty.
+        link: "/en/tools/house-buying/stamp-duty-calculator"
+      wales:
+        title: Calculate Land Transaction Tax for Wales
+        body: "Land Transaction Tax (LTT) will replace Stamp Duty in Wales. We will have a calculator for this in April but for now use the Stamp Duty Calculator."
+        link: "/en/tools/house-buying/stamp-duty-calculator"
+    how_calculated_toggle: "How is this calculated?"
+    how_calculated: "Land and Buildings Transaction Tax (LBTT) is paid at different rates, depending on the band the purchase price falls into. For example, someone buying a property for £280,000 would pay no tax on the value of the property up to £145,000, 2% tax on the property value between £145,001 and £250,000 and 5% on the property value between £250,001 and £280,000. In this case, total liability for Land and Buildings Transaction Tax (LBTT) would be £3,600 giving an effective tax rate of 1.29% (average percentage rate of tax paid)."
+    how_calculated_additional: "Anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £8,400, meaning the total stamp duty would be £12,000 giving an effective tax rate of 4.29%."
+    how_calculated_extra: "* Properties under %{amount} are not subject to second home Additional Dwelling Supplement"
+    describe_price_field: Make sure to clear the existing number before entering the new number.
+    activemodel:
+      attributes:
+        mortgage_calculator/land_and_buildings_transaction_tax:
+          price: "Property Price:"
+    results:
+      title: "Land and Buildings Transaction Tax to pay is"
+      second_title: "Land and Buildings Transaction Tax on your additional property"
+      sentence: "The effective tax rate is %{percentage}"
+      sentence_prefix: "The effective tax rate is"
+      sentence_suffix: "%"
+      click_to_expand: Click to expand.
+    table:
+      property_price_header: "Purchase price of property"
+      rate_header: "Rate of Land and Buildings Transaction Tax (LBTT)"
+      extra_rate_header: "Buy to Let/ Additional Dwelling Supplement (ADS)*"
+      max: "%{value}+"
+    next_steps:
+      learn_more:
+        title: "Did you know?"
+        tip_1: "You have to pay Land and Buildings Transaction Tax (LBTT) within 30 days of buying a property. If you're using a solicitor to carry out the conveyancing, they will normally organise the payment for you."
+        link_1:
+          title: "Land and Buildings Transaction Tax (LBTT) - Everything you need to know"
+          url: "/en/articles/land-and-buildings-transaction-tax-everything-you-need-to-know"
+      find_out_more:
+        title: Find out more
+        tips:
+          - copy_html: Upfront home buying costs
+            url: "https://www.moneyadviceservice.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
+          - copy_html: Mortgage fees and costs
+            url: "https://www.moneyadviceservice.org.uk/en/articles/mortgage-related-fees-and-costs-at-a-glance"
+          - copy_html: Costs of moving day
+            url: "https://www.moneyadviceservice.org.uk/en/articles/planning-for-the-cost-of-moving-day"
+      have_you_tried:
+        title: 'Have you tried?'
+        mortgage_calculator: "Mortgage calculator"
+        mortgage_affordability_calculator: "Affordability calculator"

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 2
-    MINOR = 4
+    MINOR = 3
     PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')

--- a/spec/controllers/land_and_buildings_transaction_taxes_controller_spec.rb
+++ b/spec/controllers/land_and_buildings_transaction_taxes_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module MortgageCalculator
+  describe LandAndBuildingsTransactionTaxesController do
+    routes { MortgageCalculator::Engine.routes }
+
+    describe '#show' do
+      it 'responds with 200' do
+        get :show
+        expect(response).to be_success
+      end
+    end
+
+    describe '#create' do
+      it 'responds with 200' do
+        post :create, land_and_buildings_transaction_tax: { price: '200000' }
+        expect(response).to be_success
+      end
+
+      context 'when price is invalid' do
+        render_views
+
+        it 'renders show template' do
+          post :create, land_and_buildings_transaction_tax: { price: 'asd' }
+          expect(response).to render_template('show')
+        end
+      end
+    end
+  end
+end
+

--- a/spec/models/land_and_buildings_transaction_tax_spec.rb
+++ b/spec/models/land_and_buildings_transaction_tax_spec.rb
@@ -1,0 +1,270 @@
+require 'spec_helper'
+
+describe MortgageCalculator::LandAndBuildingsTransactionTax do
+  describe 'default state' do
+    it 'sets price to zero' do
+      expect(subject.price).to be_zero
+    end
+
+    it 'sets buyer_type to standard by default' do
+      expect(subject.buyer_type).to eq('isNextHome')
+    end
+  end
+
+  describe '#second_home?' do
+    subject { described_class.new(buyer_type: buyer_type) }
+
+    context 'when is next home' do
+      let(:buyer_type) { 'isNextHome' }
+
+      it 'is false' do
+        expect(subject).not_to be_second_home
+      end
+    end
+
+    context 'when is second home' do
+      let(:buyer_type) { 'isSecondHome' }
+
+      it 'is true' do
+        expect(subject).to be_second_home
+      end
+    end
+  end
+
+  it_should_behave_like 'currency inputs', [:price]
+
+  describe 'calculations' do
+    let(:buyer_type) { 'isNextHome' }
+
+    subject { described_class.new(price: price, buyer_type: buyer_type) }
+
+    context 'when house price is text' do
+      let(:price) { 'asd' }
+
+      it 'has errors' do
+        subject.valid?
+        expect(subject.errors).not_to be_empty
+      end
+    end
+
+    context 'when house price is 0' do
+      let(:price) { 0 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to be_zero }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to be_zero }
+      end
+    end
+
+    context 'when house price is 39000' do
+      let(:price) { 39_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(39_000) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(39_000) }
+      end
+    end
+
+    context 'when house price is 40000' do
+      let(:price) { 40_000 }
+
+      context 'and is next home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(40_000) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(1200) }
+        its(:percentage_tax) { is_expected.to eq(3) }
+        its(:total_due) { is_expected.to eq(41_200) }
+      end
+    end
+
+    context 'when house price is 145000' do
+      let(:price) { 145_000 }
+
+      context 'and is next home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(145_000) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(4350) }
+        its(:percentage_tax) { is_expected.to eq(3) }
+        its(:total_due) { is_expected.to eq(149_350) }
+      end
+    end
+
+    context 'when house price is 185000.00' do
+      let(:price) { 185_000 }
+
+      context 'and is next home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(800) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.43) }
+        its(:total_due) { is_expected.to eql(185_800) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(6350) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(3.43) }
+        its(:total_due) { is_expected.to eq(191_350) }
+      end
+    end
+
+    context 'when house price is 275000' do
+      let(:price) { 275_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(3350) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.22) }
+        its(:total_due) { is_expected.to eql(278_350) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(11_600) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.22) }
+        its(:total_due) { is_expected.to eq(286_600) }
+      end
+    end
+
+    context 'when house price is 300,000' do
+      let(:price) { 300_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(4600) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.53) }
+        its(:total_due) { is_expected.to eql(304_600) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(13_600) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.53) }
+        its(:total_due) { is_expected.to eq(313_600) }
+      end
+    end
+
+    context 'when house price is 490,000' do
+      let(:price) { 490_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(22_350) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.56) }
+        its(:total_due) { is_expected.to eql(512_350) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(37_050) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(7.56) }
+        its(:total_due) { is_expected.to eq(527_050) }
+      end
+    end
+
+    context 'when house price is 510000.00' do
+      let(:price) { 510_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(24_350) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.77) }
+        its(:total_due) { is_expected.to eql(534_350) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(39_650) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(7.77) }
+        its(:total_due) { is_expected.to eq(549_650) }
+      end
+    end
+
+    context 'when house price is 937500' do
+      let(:price) { 937_500 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(70_850) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(7.56) }
+        its(:total_due) { is_expected.to eql(1_008_350) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(98_975) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(10.56) }
+        its(:total_due) { is_expected.to eq(1_036_475) }
+      end
+    end
+
+    context 'when house price is 2100000' do
+      let(:price) { 2_100_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(210_350) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(10.01) }
+        its(:total_due) { is_expected.to eql(2_310_350) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(273_350) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(13.02) }
+        its(:total_due) { is_expected.to eq(2_373_350) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP 8798](https://moneyadviceservice.tpondemand.com/entity/8798-create-land-and-buildings-transaction-tax)

PART 2

Adds LBTT Calculator based on the changes in https://github.com/moneyadviceservice/mortgage_calculator/pull/325

The main difference between this and the stamp duty calculator is that the banding is different and there is no break for first time buyers. As such the majority of the testing is centred around the calculations being correct for given inputs as behaviourally it is identical.