### PR TITLE
[DEV APPROVED] 8798 Fix error with LBTT Calculations

### DIFF
--- a/app/helpers/mortgage_calculator/land_and_buildings_transaction_taxes_helper.rb
+++ b/app/helpers/mortgage_calculator/land_and_buildings_transaction_taxes_helper.rb
@@ -17,7 +17,7 @@ module MortgageCalculator
     end
 
     def calculator_config_json
-      calculator = MortgageCalculator::StampDuty
+      calculator = MortgageCalculator::LandAndBuildingsTransactionTax
       {
         standard: calculator::STANDARD_BANDS,
         second_home_tax_rate: calculator::SECOND_HOME_ADDITIONAL_TAX,

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 2
     MINOR = 5
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/spec/helpers/land_and_buildings_transaction_taxes_helper_spec.rb
+++ b/spec/helpers/land_and_buildings_transaction_taxes_helper_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+module MortgageCalculator
+  describe LandAndBuildingsTransactionTaxesHelper do
+    describe '#calculator_config_json' do
+      it 'sets the first theshold to the correct value' do
+        config = JSON.parse(calculator_config_json)
+        expect(config["standard"].first["threshold"]).to eq(145000)
+      end
+    end
+  end
+end

--- a/spec/helpers/stamp_duties_helper_spec.rb
+++ b/spec/helpers/stamp_duties_helper_spec.rb
@@ -27,5 +27,12 @@ module MortgageCalculator
         expect(ftb_threshold).to eq('£500,000')
       end
     end
+
+    describe '#calculator_config_json' do
+      it 'it sets first threshold to the correct value' do
+        config = JSON.parse(calculator_config_json)
+        expect(config["standard"].first["threshold"]).to eq(125000)
+      end
+    end
   end
 end


### PR DESCRIPTION
[TP 8798](https://moneyadviceservice.tpondemand.com/entity/8798-create-land-and-buildings-transaction-tax)

PART 3!

During PR feedback on https://github.com/moneyadviceservice/mortgage_calculator/pull/326 I introduced a bug by using the wrong calculation in the LBTT Javascript configuration when moving it to a helper from the controller. 

This also showed that I was missing a check to make sure the config was being set correctly. This PR adds a check for the config and fixes the bug.