### PR TITLE
[WIP] Add LBTT Calculator

### DIFF
--- a/app/controllers/mortgage_calculator/land_transaction_taxes_controller.rb
+++ b/app/controllers/mortgage_calculator/land_transaction_taxes_controller.rb
@@ -1,0 +1,36 @@
+module MortgageCalculator
+  class LandTransactionTaxesController < ::MortgageCalculator::ApplicationController
+    CALCULATOR = MortgageCalculator::LandTransactionTax
+    before_action :set_rates
+    def show
+      @ltt = CALCULATOR.new
+    end
+
+    def create
+      @ltt = CALCULATOR.new(
+        params.require(:land_transaction_tax)
+        .permit(:price, :buyer_type)
+        .symbolize_keys
+      )
+      unless @ltt.valid?
+        render :show
+      end
+    end
+
+    private
+
+    def set_rates
+      @rates = CALCULATOR.banding_for(
+        CALCULATOR::STANDARD_BANDS
+      )
+    end
+
+    def category_id
+      'buying-a-home'
+    end
+
+    def tool_name
+      I18n.translate('land_transaction_tax.tool_name')
+    end
+  end
+end

--- a/app/helpers/mortgage_calculator/land_transaction_taxes_helper.rb
+++ b/app/helpers/mortgage_calculator/land_transaction_taxes_helper.rb
@@ -1,0 +1,41 @@
+module MortgageCalculator
+  module LandTransactionTaxesHelper
+    def band(num1, num2)
+      num1 = num1.ceil
+      return maximum_band(num1 - 1) if num2.nil?
+      "#{formatted_currency(num1)} - #{formatted_currency(num2)}"
+    end
+
+    def second_home_rate(rate)
+      rate + LandTransactionTax::SECOND_HOME_ADDITIONAL_TAX
+    end
+
+    def second_home_threshold
+      formatted_currency(
+        MortgageCalculator::LandTransactionTax::SECOND_HOME_THRESHOLD
+      )
+    end
+
+    def calculator_config_json
+      calculator = MortgageCalculator::LandTransactionTax
+      {
+        standard: calculator::STANDARD_BANDS,
+        second_home_tax_rate: calculator::SECOND_HOME_ADDITIONAL_TAX,
+        second_home_threshold: calculator::SECOND_HOME_THRESHOLD
+      }.to_json
+    end
+
+    private
+
+    def maximum_band(num)
+      I18n.t(
+        'land_transaction_tax.table.max',
+        value: formatted_currency(num)
+      )
+    end
+
+    def formatted_currency(num)
+      number_to_currency(num, precision: 0)
+    end
+  end
+end

--- a/app/models/mortgage_calculator/land_transaction_tax.rb
+++ b/app/models/mortgage_calculator/land_transaction_tax.rb
@@ -1,0 +1,22 @@
+module MortgageCalculator
+  class LandTransactionTax < TaxCalculator
+    def self.i18n_scope
+      'land_transaction_tax.activemodel'
+    end
+
+    STANDARD_BANDS = [
+      { threshold: 180_000, rate: 0 },
+      { threshold: 250_000, rate: 3.5 },
+      { threshold: 400_000, rate: 5 },
+      { threshold: 750_000, rate: 7.5 },
+      { threshold: 1_500_000, rate: 10 },
+      { threshold: nil, rate: 12 }
+    ].freeze
+
+    protected
+
+    def bands_to_use
+      STANDARD_BANDS
+    end
+  end
+end

--- a/app/views/mortgage_calculator/land_transaction_taxes/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_bands_table.html.erb
@@ -1,0 +1,18 @@
+<table class="mortgagecalc__table stamp-duty__table">
+  <thead>
+    <tr>
+      <th class="mortgagecalc__table__price"><%= I18n.t("land_transaction_tax.table.property_price_header") %></th>
+      <th class="mortgagecalc__table__rate"><%= I18n.t("land_transaction_tax.table.rate_header") %></th>
+      <th class="mortgagecalc__table__extra"><%= I18n.t("land_transaction_tax.table.extra_rate_header") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @rates.each do |rate| %>
+      <tr>
+        <td class="mortgagecalc__table__price"><%= band(rate[:start], rate[:end]) %></td>
+        <td class="mortgagecalc__table__rate"><%= rate[:rate] %>%</td>
+        <td class="mortgagecalc__table__extra"><%= second_home_rate(rate[:rate]) %>%</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_elsewhere.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_elsewhere.html.erb
@@ -1,0 +1,19 @@
+<div class="l-constrained elsewhere__container">
+  <a class="elsewhere__item promo__link" href="<%= t('land_transaction_tax.elsewhere.england_ni.link') %>">
+    <div class="elsewhere__item-content">
+    <h3 class="promo__heading"><%= t('land_transaction_tax.elsewhere.england_ni.title') %></h3>
+    <p class="promo__content"><%= t('land_transaction_tax.elsewhere.england_ni.body') %></p></div>
+    <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right elsewhere__arrow" focusable="false">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right"></use>
+    </svg>
+  </a>
+  <a class="elsewhere__item promo__link" href="<%= t('land_transaction_tax.elsewhere.scotland.link') %>">
+    <div class="elsewhere__item-content">
+    <h3 class="promo__heading"><%= t('land_transaction_tax.elsewhere.scotland.title') %></h3>
+    <p class="promo__content"><%= t('land_transaction_tax.elsewhere.scotland.body') %></p>
+    </div>
+    <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right elsewhere__arrow" focusable="false">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right"></use>
+    </svg>
+  </a>
+</div>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_form_step1.html.erb
@@ -1,0 +1,55 @@
+<%= form_for @ltt, url: land_transaction_tax_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_one stamp-duty__step-one', novalidate: '' } do |f| %>
+
+  <%= f.label :buyer_type, class: 'stamp-duty__buyer-type' do %>
+    <%= t('land_transaction_tax.select.label') %>
+    <%= f.select(:buyer_type, [
+      [t('land_transaction_tax.select.option_prompt'), ''],
+      [t('land_transaction_tax.select.option_isNextHome'), 'isNextHome'],
+      [t('land_transaction_tax.select.option_isSecondHome'), 'isSecondHome']
+      ], {}, {'ng-model' => 'stampDuty.buyerType'}
+    )%>
+    <span data-dough-component="PopupTip">
+      <%= popup_tip_trigger options: {
+        text: t('land_transaction_tax.tooltip_show')
+      } %>
+      <%= popup_tip_content options: {
+        text: t('land_transaction_tax.select.tooltip_html'),
+        classname: 'details__helper',
+        tooltip_hide: t('land_transaction_tax.tooltip_hide')
+      } %>
+    </span>
+  <% end %>
+
+  <div class="stamp-duty__form form__item">
+    <%= f.label :price, class: "stamp-duty__input-description" %>
+    <div class="visually-hidden" id="mc_accessibility_describe_price"><%= t 'land_transaction_tax.describe_price_field' %></div>
+
+    <span class="stamp-duty__input-wrapper stamp-duty__input-wrapper--inline">
+      <span class="stamp-duty__input--unit">£</span>
+      <%= f.text_field :price,
+      :value => @ltt.price_formatted,
+      "autofocus" => '',
+      "ng-model" => "stampDuty.propertyPrice",
+      "placeholder" => "0",
+      "currency" => '',
+      "data-m-dec" =>"0",
+      "pattern" => '\d*',
+      "class" => 'stamp-duty__input' %>
+    </span>
+
+    <%= f.submit I18n.t("land_transaction_tax.next"),
+    class: "button button--primary stamp-duty__submit",
+      'ng-click' => 'navigateAndFocus($event)',
+      'ng-disabled' => '!stampDuty.propertyPrice || !stampDuty.buyerType',
+      'analytics-category' => 'Stamp Duty Calculator',
+      'analytics-action' => 'Completion',
+      'analytics-label' => 'Click',
+      'analytics' => '',
+      'analytics-on' => 'click'
+    %>
+  </div>
+<% end %>
+<hr />
+
+<h2><%= t('land_transaction_tax.elsewhere.title') %></h2>
+<p><%= t('land_transaction_tax.elsewhere.body') %></p>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_form_step2.html.erb
@@ -1,0 +1,83 @@
+<div class="stamp-duty__calculator-column">
+  <%= form_for @ltt, url: land_transaction_tax_path, html: { id: 'update_stamp_duty', name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
+    <div class="form__item stamp-duty__form">
+      <%= f.label :price, class: 'stamp-duty__input-description' %>
+      <div class="visually-hidden"
+            id="mc_accessibility_describe_price">
+        <%= t 'land_transaction_tax.describe_price_field' %>
+      </div>
+
+      <span class="stamp-duty__input-wrapper">
+        <span class="stamp-duty__input--unit">£</span>
+        <%= f.text_field :price,
+                         :value => @ltt.price_formatted,
+                         class: 'stamp-duty__input dynamic-slider-property',
+                         "ng-model" => "stampDuty.propertyPrice",
+                         "placeholder" => "0.00",
+                         "currency" => '',
+                         "data-m-dec" => "0",
+                         "analytics" => "",
+                         "analytics-on" => "change",
+                         "analytics-category" => "Stamp Duty Calculator",
+                         "analytics-action" => "Refinement",
+                         "analytics-label" => "Price",
+                         "pattern" => '\d*',
+                         "aria-describedby" => 'mc_accessibility_describe_price',
+                         "autoselect" => ""
+                         %>
+      </span>
+
+    </div>
+    <%= f.hidden_field :buyer_type %>
+
+    <div class="slider"
+          ui-slider
+          dynamic-for='dynamic-slider-property'
+          ng-model="stampDuty.propertyPrice"
+          analytics-category="Stamp Duty"
+          analytics-action="Refinement"
+          analytics-label="Price"
+          aria-hidden="true">
+    </div>
+
+    <div class="hide-with-js">
+      <p><br><%= f.submit I18n.t("land_transaction_tax.recalculate"),
+                          'class' => 'button',
+                          'wz-next' => '' %></p>
+    </div>
+
+  <% end %>
+
+  <%= render 'stamp_duty_to_pay_panel' if @ltt.valid? %>
+
+  <div class="">
+    <h2 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h2>
+    <p><%= link_to t('land_transaction_tax.next_steps.have_you_tried.mortgage_calculator'),
+                   full_mortgage_calculator_url,
+                   class: "button button--primary mortgagecalc__spread stamp-duty__button",
+                   target: "_blank",
+                   rel: no_follow? %>
+
+      <%= link_to t('land_transaction_tax.next_steps.have_you_tried.mortgage_affordability_calculator'),
+                   full_mortgage_affordability_calculator_url,
+                   class: "button button--primary mortgagecalc__spread stamp-duty__button",
+                   target: "_blank",
+                   rel: no_follow? %></p>
+  </div>
+</div>
+
+<div class="stamp-duty__info-column">
+  <div class="callout callout--tip">
+    <span class="callout__icon" aria-hidden="true">?</span>
+    <h2 class="stamp-duty__info-subheading callout__heading"><%= I18n.t("land_transaction_tax.next_steps.learn_more.title") %></h2>
+    <p class="stamp-duty__info-tip"><%= I18n.t("land_transaction_tax.next_steps.learn_more.tip_1") %></p>
+    <p><a class="stamp-duty__info-tip-link" href="<%= I18n.t("land_transaction_tax.next_steps.learn_more.link_1.url") %>"><%= I18n.t("land_transaction_tax.next_steps.learn_more.link_1.title") %></a>
+  </div>
+
+  <h2 class="mortgagecalc__subheading"><%= I18n.t("land_transaction_tax.next_steps.find_out_more.title") %>:</h2>
+  <ul>
+    <% I18n.t("land_transaction_tax.next_steps.find_out_more.tips").each do |tip| %>
+      <li class="stamp-duty__info-tip-link"><%= link_to tip[:copy_html], tip[:url], target: "_blank", rel: no_follow? %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_next_home_buyer_explanation.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_next_home_buyer_explanation.html.erb
@@ -1,0 +1,6 @@
+<p><%= I18n.t("land_transaction_tax.how_calculated") %></p>
+<p><%= I18n.t("land_transaction_tax.how_calculated_additional") %></p>
+
+<%= render 'bands_table', rates: @rates %>
+
+<p><%= I18n.t('land_transaction_tax.how_calculated_extra', amount: second_home_threshold) %></p>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_seo_links.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_seo_links.html.erb
@@ -1,0 +1,11 @@
+<div class="mortgagecalc__panel">
+  <h2 class="mortgagecalc__heading"><%= t("affordability.next_steps.have_you_tried.title") %></h2>
+
+  <p><%= link_to I18n.t('land_transaction_tax.next_steps.have_you_tried.mortgage_calculator'),
+                   full_mortgage_calculator_url,
+                   target: "_blank" %></p>
+
+  <p><%= link_to I18n.t('land_transaction_tax.next_steps.have_you_tried.mortgage_affordability_calculator'),
+                   full_mortgage_affordability_calculator_url,
+                   target: "_blank" %></p>
+</div>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_stamp_duty_tip.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_stamp_duty_tip.html.erb
@@ -1,0 +1,13 @@
+<div class="mortgagecalc__panel--full">
+  <div ng-show="expandedStampDutyInformation" class="mortgagecalc__tip">
+    <div class="stamp-duty stamp-duty__calculation-explanation">
+        <div ng-hide="js" class="stamp-duty__explanation-nexthome ng-hide is-active">
+          <%= render 'next_home_buyer_explanation' %>
+        </div>
+
+      <div class="rendered-from-js stamp-duty__explanation-nexthome">
+        <%= render 'next_home_buyer_explanation' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
@@ -1,0 +1,58 @@
+<div class="stamp-duty__results">
+  <div class="stamp-duty__results-heading" aria-live="polite" aria-atomic="true">
+    <div ng-hide="js">
+      <% key = @ltt.second_home? ? 'second_title' : 'title' %>
+      <%= I18n.t("land_transaction_tax.results.#{key}") %>
+    </div>
+    <div class="hidden-unless-js">
+      <span ng-if="stampDuty.isSecondHome">
+        <%= I18n.t('land_transaction_tax.results.second_title') %>
+      </span>
+      <span ng-if="!stampDuty.isSecondHome">
+        <%= I18n.t('land_transaction_tax.results.title') %>
+      </span>
+    </div>
+
+    <span ng-hide="js">
+      <%= number_to_currency @ltt.tax_due_formatted %>
+    </span>
+    <span class="rendered-from-js">
+      {{ stampDuty.cost() | customCurrency:"£" }}
+    </span>
+  </div>
+
+  <p ng-hide="js" class="stamp-duty__results-tax-rate ng-hide">
+    <%= I18n.t('land_transaction_tax.results.sentence',
+              percentage: number_to_percentage(
+                @ltt.percentage_tax, precision: 2
+              )
+        )
+    %>
+  </p>
+
+  <p class="rendered-from-js stamp-duty__results-tax-rate">
+    <%= I18n.t('land_transaction_tax.results.sentence_prefix') %>
+    {{ stampDuty.percentageTax() | number: 2 }}
+    <%= I18n.t('land_transaction_tax.results.sentence_suffix') %>
+  </p>
+
+  <p class="rendered-from-js stamp-duty__FTB_conditional">
+    <%= I18n.t('land_transaction_tax.results.FTB_conditional', amount: 0) %>
+  </p>
+
+  <div>
+    <a href="#"
+       class="rendered-from-js
+              expander expander--nudge
+              stamp-duty__how-calculated-toggle"
+                ng-class="{ 'expander--expanded' : expandedStampDutyInformation }"
+                ng-click="toggleStampDutyExpanded($event)"
+                affects-height="click">
+      <%= I18n.t('land_transaction_tax.how_calculated_toggle') %>
+      <span class="visually-hidden">
+        <%= I18n.t('land_transaction_tax.results.click_to_expand') %>
+      </span>
+    </a>
+    <%= render 'stamp_duty_tip' %>
+  </div>
+</div>

--- a/app/views/mortgage_calculator/land_transaction_taxes/create.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/create.html.erb
@@ -1,0 +1,6 @@
+<div class="stamp-duty">
+  <div class="stamp-duty__container">
+    <h1 class="stamp-duty__heading"><%= I18n.t('land_transaction_tax.heading_results') %></h1>
+    <%= render 'form_step2' %>
+  </div>
+</div>

--- a/app/views/mortgage_calculator/land_transaction_taxes/show.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/show.html.erb
@@ -1,0 +1,31 @@
+<% content_for(:head) do %>
+  <script>
+   window.calculator_config = <%= raw calculator_config_json %>;
+  </script>
+<% end %>
+
+<div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
+  <% @ltt.errors.full_messages.each do |message| %>
+    <span style="color:red;"><%= message %></span>
+  <% end %>
+  <div wizard on-finish="finishedWizard()" hide-indicators='true'>
+    <div wz-step class="ng-hide">
+      <div class="stamp-duty__container">
+        <h1 class="stamp-duty__heading"><%= I18n.t('land_transaction_tax.heading') %></h1>
+        <h2 class="intro stamp-duty__subheading"><%= I18n.t('land_transaction_tax.title') %></h2>
+        <%= render 'form_step1' %>
+      </div>
+      <%= render 'elsewhere' %>
+    </div>
+
+    <div wz-step class="ng-hide">
+
+      <div class="rendered-from-js">
+        <div class="stamp-duty__container">
+          <h1 class="stamp-duty__heading"><%= I18n.t('land_transaction_tax.heading_results') %></h1>
+          <%= render 'form_step2' %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/land_transaction_tax.en.yml
+++ b/config/locales/land_transaction_tax.en.yml
@@ -1,0 +1,72 @@
+en:
+  land_transaction_tax:
+    meta:
+      title: "Land Transaction Tax calculator"
+      description: "Calculate the Land and Buildings Transaction Tax on your residential property in Wales"
+      canonical_url: "https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-transaction-tax-calculator"
+    tooltip_show: show help
+    tooltip_hide: hide help
+    tool_name: "land-transaction-tax-calculator"
+    heading: "Land Transaction Tax (LTT) calculator"
+    heading_results: "Land Transaction Tax (LTT) calculator - Your Results"
+    title: "Calculate the Land and Buildings Transaction Tax on your residential property in Wales"
+    next: Next
+    select:
+      label: I am
+      option_prompt: please select an option
+      option_isNextHome: buying my next home
+      option_isSecondHome: buying an additional or buy-to-let property
+      tooltip_html: "Anyone purchasing an additional home including buy to let properties over the value of £40,000 will have to pay an extra 3% surcharge on top of each Land Transaction Tax band."
+    recalculate: Recalculate
+    elsewhere:
+      title: "Buying in England, Northern Ireland or Scotland?"
+      body: "If you are buying in any of these countries then use the appropriate calculator to work out how much you will pay"
+      england_ni:
+        title: Calculate Stamp Duty in England or Northern Ireland
+        body: Properties in England and Northen Ireland are still subject to Stamp Duty.
+        link: "/en/tools/house-buying/stamp-duty-calculator"
+      scotland:
+        title: Calculate Land Transaction Tax for Scotland
+        body: "Calculate Land and Buildings Transaction Tax for Scotland."
+        link: "/en/tools/house-buying/land-and-buildings-transaction-tax-calculator"
+    how_calculated_toggle: "How is this calculated?"
+    how_calculated: "Land Transaction Tax (LTT) is paid at different rates, depending on the band the purchase price falls into. For example, someone buying a property for £280,000 would pay no tax on the value of the property up to £180,000, 3.5% tax on the property value between £180,001 and £250,000 and 5% on the property value between £250,001 and £280,000. In this case, total liability for Land and Buildings Transaction Tax (LTT) would be £3,950 giving an effective tax rate of 1.41% (average percentage rate of tax paid)."
+    how_calculated_additional: "Anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £8,400, meaning the total stamp duty would be £12,350 giving an effective tax rate of 4.41%."
+    how_calculated_extra: "* Properties under %{amount} are not subject to additional home surcharge."
+    describe_price_field: Make sure to clear the existing number before entering the new number.
+    activemodel:
+      attributes:
+        mortgage_calculator/land_transaction_tax:
+          price: "Property Price:"
+    results:
+      title: "Land and Buildings Transaction Tax to pay is"
+      second_title: "Land and Buildings Transaction Tax on your additional property"
+      sentence: "The effective tax rate is %{percentage}"
+      sentence_prefix: "The effective tax rate is"
+      sentence_suffix: "%"
+      click_to_expand: Click to expand.
+    table:
+      property_price_header: "Purchase price of property"
+      rate_header: "Rate of Land and Buildings Transaction Tax"
+      extra_rate_header: "Buy to Let/Additional Home rate *"
+      max: "%{value}+"
+    next_steps:
+      learn_more:
+        title: "Did you know?"
+        tip_1: "You have to pay Land Transaction Tax within 30 days of buying a property. If you're using a solicitor to carry out the conveyancing, they will normally organise the payment for you."
+        link_1:
+          title: "Land Transaction Tax – Everything you need to know"
+          url: "/en/articles/land-transaction-tax-everything-you-need-to-know"
+      find_out_more:
+        title: Find out more
+        tips:
+          - copy_html: Upfront home buying costs
+            url: "https://www.moneyadviceservice.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
+          - copy_html: Mortgage fees and costs
+            url: "https://www.moneyadviceservice.org.uk/en/articles/mortgage-related-fees-and-costs-at-a-glance"
+          - copy_html: Costs of moving day
+            url: "https://www.moneyadviceservice.org.uk/en/articles/planning-for-the-cost-of-moving-day"
+      have_you_tried:
+        title: 'Have you tried?'
+        mortgage_calculator: "Mortgage calculator"
+        mortgage_affordability_calculator: "Affordability calculator"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ MortgageCalculator::Engine.routes.draw do
   resource :land_and_buildings_transaction_tax, path: 'cyfrifiannell-treth-trafodion-tir-ac-adeiladau'
   resource :land_and_buildings_transaction_tax
 
+  resource :land_transaction_tax, path: 'land-transaction-tax-calculator'
+  resource :land_transaction_tax
+
   resource :affordability, path: "mortgage-affordability-calculator" do
     get '/', to: "affordabilities#step_1"
     collection do

--- a/spec/controllers/land_transaction_taxes_controller_spec.rb
+++ b/spec/controllers/land_transaction_taxes_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+module MortgageCalculator
+  describe LandTransactionTaxesController do
+    routes { MortgageCalculator::Engine.routes }
+
+    describe '#show' do
+      it 'responds with 200' do
+        get :show
+        expect(response).to be_success
+      end
+    end
+
+    describe '#create' do
+      it 'responds with 200' do
+        post :create, land_transaction_tax: { price: '200000' }
+        expect(response).to be_success
+      end
+
+      context 'when price is invalid' do
+        render_views
+
+        it 'renders show template' do
+          post :create, land_transaction_tax: { price: 'asd' }
+          expect(response).to render_template('show')
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/land_transaction_taxes_helper_spec.rb
+++ b/spec/helpers/land_transaction_taxes_helper_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+module MortgageCalculator
+  describe LandTransactionTaxesHelper do
+    describe '#calculator_config_json' do
+      it 'sets the first theshold to the correct value' do
+        config = JSON.parse(calculator_config_json)
+        expect(config["standard"].first["threshold"]).to eq(180000)
+      end
+    end
+  end
+end

--- a/spec/models/land_transaction_tax_spec.rb
+++ b/spec/models/land_transaction_tax_spec.rb
@@ -1,0 +1,270 @@
+require 'spec_helper'
+
+describe MortgageCalculator::LandTransactionTax do
+  describe 'default state' do
+    it 'sets price to zero' do
+      expect(subject.price).to be_zero
+    end
+
+    it 'sets buyer_type to standard by default' do
+      expect(subject.buyer_type).to eq('isNextHome')
+    end
+  end
+
+  describe '#second_home?' do
+    subject { described_class.new(buyer_type: buyer_type) }
+
+    context 'when is next home' do
+      let(:buyer_type) { 'isNextHome' }
+
+      it 'is false' do
+        expect(subject).not_to be_second_home
+      end
+    end
+
+    context 'when is second home' do
+      let(:buyer_type) { 'isSecondHome' }
+
+      it 'is true' do
+        expect(subject).to be_second_home
+      end
+    end
+  end
+
+  it_should_behave_like 'currency inputs', [:price]
+
+  describe 'calculations' do
+    let(:buyer_type) { 'isNextHome' }
+
+    subject { described_class.new(price: price, buyer_type: buyer_type) }
+
+    context 'when house price is text' do
+      let(:price) { 'asd' }
+
+      it 'has errors' do
+        subject.valid?
+        expect(subject.errors).not_to be_empty
+      end
+    end
+
+    context 'when house price is 0' do
+      let(:price) { 0 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to be_zero }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to be_zero }
+      end
+    end
+
+    context 'when house price is 39000' do
+      let(:price) { 39_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(39_000) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(39_000) }
+      end
+    end
+
+    context 'when house price is 40000' do
+      let(:price) { 40_000 }
+
+      context 'and is next home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(40_000) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(1200) }
+        its(:percentage_tax) { is_expected.to eq(3) }
+        its(:total_due) { is_expected.to eq(41_200) }
+      end
+    end
+
+    context 'when house price is 145000' do
+      let(:price) { 145_000 }
+
+      context 'and is next home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(145_000) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(4350) }
+        its(:percentage_tax) { is_expected.to eq(3) }
+        its(:total_due) { is_expected.to eq(149_350) }
+      end
+    end
+
+    context 'when house price is 185000.00' do
+      let(:price) { 185_000 }
+
+      context 'and is next home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(175) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.09) }
+        its(:total_due) { is_expected.to eql(185_175) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(5725) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(3.09) }
+        its(:total_due) { is_expected.to eq(190_725) }
+      end
+    end
+
+    context 'when house price is 275000' do
+      let(:price) { 275_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(3700) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.35) }
+        its(:total_due) { is_expected.to eql(278_700) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(11_950) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.35) }
+        its(:total_due) { is_expected.to eq(286_950) }
+      end
+    end
+
+    context 'when house price is 300,000' do
+      let(:price) { 300_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(4950) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.65) }
+        its(:total_due) { is_expected.to eql(304_950) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(13_950) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.65) }
+        its(:total_due) { is_expected.to eq(313_950) }
+      end
+    end
+
+    context 'when house price is 490,000' do
+      let(:price) { 490_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(16_700) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(3.41) }
+        its(:total_due) { is_expected.to eql(506_700) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(31_400) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(6.41) }
+        its(:total_due) { is_expected.to eq(521_400) }
+      end
+    end
+
+    context 'when house price is 510000.00' do
+      let(:price) { 510_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(18_200) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(3.57) }
+        its(:total_due) { is_expected.to eql(528_200) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(33_500) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(6.57) }
+        its(:total_due) { is_expected.to eq(543_500) }
+      end
+    end
+
+    context 'when house price is 937500' do
+      let(:price) { 937_500 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(54_950) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(5.86) }
+        its(:total_due) { is_expected.to eql(992_450) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(83_075) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(8.86) }
+        its(:total_due) { is_expected.to eq(1_020_575) }
+      end
+    end
+
+    context 'when house price is 2100000' do
+      let(:price) { 2_100_000 }
+
+      context 'and is not a second home' do
+        let(:buyer_type) { 'isNextHome' }
+
+        its(:tax_due) { is_expected.to eql(183_200) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(8.72) }
+        its(:total_due) { is_expected.to eql(2_283_200) }
+      end
+
+      context 'and is a second home' do
+        let(:buyer_type) { 'isSecondHome' }
+
+        its(:tax_due) { is_expected.to eq(246_200) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(11.72) }
+        its(:total_due) { is_expected.to eq(2_346_200) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP 8974](https://moneyadviceservice.tpondemand.com/entity/8974-land-transaction-tax-calculator-stamp-duty)

This adds the new Land Transaction Tax Calculator for Wales. This happens to be fairly similar to the LBTT Calculator for Scotland with different banding.

Outstanding work:

- Add Welsh Translations
- Add [Welsh Routes](https://github.com/moneyadviceservice/mortgage_calculator/compare/8974_create_land_transaction_tax_wales_calc?expand=1#diff-21497849d8f00507c9c8dcaf6288b136R34)

