### PR TITLE
8798 - Add feature tests for land and buildings transaction tax (Scotland)

### DIFF
--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
@@ -36,10 +36,6 @@
     <%= I18n.t('land_and_buildings_transaction_tax.results.sentence_suffix') %>
   </p>
 
-  <p class="rendered-from-js stamp-duty__FTB_conditional">
-    <%= I18n.t('land_and_buildings_transaction_tax.results.FTB_conditional', amount: 0) %>
-  </p>
-
   <div>
     <a href="#"
        class="rendered-from-js

--- a/features/land_buildings_transaction_tax_calculator.feature
+++ b/features/land_buildings_transaction_tax_calculator.feature
@@ -1,0 +1,81 @@
+Feature: Land and Buildings Transaction Tax Calculator
+  As a user
+  I want to enter my house price
+  So that I know how much land and buildings transaction tax to pay
+
+  Background:
+    Given I visit the land and buildings transaction tax page
+
+  Scenario Outline: taxes for next home
+    When I enter a house price of <price>
+    And I am a next home buyer
+    And I click next
+    And I see the stamp duty I will have to pay is "£<duty>"
+    And I see the effective tax rate is "<effective tax>"
+
+  Examples:
+    | price   | duty   | effective tax |
+    | 39000   | 0      | 0.00%         |
+    | 40000   | 0      | 0.00%         |
+    | 120000  | 0      | 0.00%         |
+    | 126000  | 0      | 0.00%         |
+    | 260000  | 2,600  | 1.00%         |
+    | 300019  | 4,600  | 1.53%         |
+    | 350000  | 8,350  | 2.39%         |
+    | 450000  | 18,350 | 4.08%         |
+    | 550000  | 28,350 | 5.15%         |
+    | 901000  | 66,470 | 7.38%         |
+
+  @javascript
+  Scenario Outline: tax for next home
+    When I enter a house price of <price>
+    And I am a next home buyer
+    And I click next
+    Then I see the stamp duty I will have to pay is "£<duty>"
+
+  Examples:
+    | price   | duty   | effective tax |
+    | 39000   | 0      | 0.00%         |
+    | 40000   | 0      | 0.00%         |
+    | 120000  | 0      | 0.00%         |
+    | 126000  | 0      | 0.00%         |
+    | 260000  | 2,600  | 1.00%         |
+    | 300019  | 4,600  | 1.53%         |
+    | 350000  | 8,350  | 2.39%         |
+    | 450000  | 18,350 | 4.08%         |
+    | 550000  | 28,350 | 5.15%         |
+    | 901000  | 66,470 | 7.38%         |
+
+  Scenario: I recalculate for next home
+    When I enter a house price of 260000
+    And I am a next home buyer
+    And I click next
+    And I see the stamp duty I will have to pay is "£2,600"
+    Then I reenter my house price with "426000"
+    And I click next again
+    And I see the stamp duty I will have to pay is "£15,950"
+    And I see the effective tax rate is "3.74%"
+
+  @javascript
+  Scenario: I recalculate for next home
+    When I enter a house price of 260000
+    And I am a next home buyer
+    And I click next
+    And I see the stamp duty I will have to pay is "£2,600"
+    Then I reenter my house price with "426000"
+    And I click next again
+    And I see the stamp duty I will have to pay is "£15,950"
+
+  Scenario Outline: Buy to let buyer
+    Given I am an additional or buy-to-let property buyer
+    When I enter a house price of <price>
+    And I click next
+    And I see the stamp duty I will have to pay is "£<duty>"
+    And I see the effective tax rate is "<effective tax>"
+
+    Examples:
+      | price   | duty   | effective tax |
+      | 35000   | 0      | 0.00%         |
+      | 50000   | 1,500  | 3.00%         |
+      | 260000  | 10,400 | 4.00%         |
+      | 750000  | 70,850 | 9.45%         |

--- a/features/step_definitions/land_and_buildings_transaction_tax.rb
+++ b/features/step_definitions/land_and_buildings_transaction_tax.rb
@@ -1,0 +1,4 @@
+Given('I visit the land and buildings transaction tax page') do
+  @stamp_duty = UI::Pages::LandAndBuildingsTransactionTax.new
+  @stamp_duty.load
+end

--- a/features/support/ui/pages/land_and_buildings_transaction_tax.rb
+++ b/features/support/ui/pages/land_and_buildings_transaction_tax.rb
@@ -1,0 +1,14 @@
+require_relative './stamp_duty'
+
+module UI
+  module Pages
+    class LandAndBuildingsTransactionTax < UI::Pages::StampDuty
+      include DefaultLocale
+
+      set_url '/{locale}/mortgage_calculator/land-and-buildings-transaction-tax-calculator'
+      element :buyer_type, "form.step_one select[name='buyer_type']"
+      element :property_price, "form.step_one input[name='land_and_buildings_transaction_tax[price]']"
+      element :property_price_step_two, "form.step_two input[name='land_and_buildings_transaction_tax[price]']"
+    end
+  end
+end


### PR DESCRIPTION
[TP Card](https://moneyadviceservice.tpondemand.com/entity/8798-land-and-buildings-transaction-tax-scotland)

## Context

The Land & Buildings Transaction Tax calculator was developed, refer to #325 and #326, The approach used to build this tool resulted in a lot ot duplicated code across c the Stamp Duty, Land & Buildings Transaction tax calculator and Land Transaction tax calculators.

This pr begins the refactoring by adding feature tests for the Land & Buildings Transaction tax calculator to facilitate the refactor.

## Observation

* Since there were already cucumber steps for the stamp duty in place, the only thing to do in the feature tests is to point them to the land and buildings transaction tax instead.
* The first time buyer locale was removed from because this tool does not have the first time buyers option. Probably it was a copy and paste. And this was preventing for the dummy app to work since the dummy app raises error for translation missing.

After this the controllers, helpers and views could be refactored.

## Next Pull requests

- [ ] Add feature tests for the Wales calculator
- [ ] Refactor the Scotland and Wales controllers
- [ ] Refactor the Scotland and Wales helpers
- [ ] Refactor the Scotland and Wales views