### PR TITLE
Add feature tests for land transaction tax for Wales

### DIFF
--- a/app/views/mortgage_calculator/land_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
@@ -36,10 +36,6 @@
     <%= I18n.t('land_transaction_tax.results.sentence_suffix') %>
   </p>
 
-  <p class="rendered-from-js stamp-duty__FTB_conditional">
-    <%= I18n.t('land_transaction_tax.results.FTB_conditional', amount: 0) %>
-  </p>
-
   <div>
     <a href="#"
        class="rendered-from-js

--- a/features/land_transaction_tax_calculator.feature
+++ b/features/land_transaction_tax_calculator.feature
@@ -1,0 +1,77 @@
+Feature: Land Transaction Tax Calculator
+  As a user
+  I want to enter my house price
+  So that I know how much land transaction tax to pay
+
+  Background:
+    Given I visit the land transaction tax page
+
+  Scenario Outline: taxes for next home
+    When I enter a house price of <price>
+    And I am a next home buyer
+    And I click next
+    And I see the stamp duty I will have to pay is "£<duty>"
+    And I see the effective tax rate is "<effective tax>"
+
+  Examples:
+    | price   | duty    | effective tax |
+    | 39000   | 0       | 0.00%         |
+    | 40000   | 0       | 0.00%         |
+    | 179000  | 0       | 0.00%         |
+    | 260000  | 2,950   | 1.13%         |
+    | 450000  | 13,700  | 3.04%         |
+    | 800000  | 41,200  | 5.15%         |
+    | 2000000 | 171,200 | 8.56%         |
+
+  @javascript
+  Scenario Outline: tax for next home
+    When I enter a house price of <price>
+    And I am a next home buyer
+    And I click next
+    Then I see the stamp duty I will have to pay is "£<duty>"
+
+  Examples:
+    | price   | duty    | effective tax |
+    | 39000   | 0       | 0.00%         |
+    | 40000   | 0       | 0.00%         |
+    | 179000  | 0       | 0.00%         |
+    | 260000  | 2,950   | 1.13%         |
+    | 450000  | 13,700  | 3.04%         |
+    | 800000  | 41,200  | 5.15%         |
+    | 2000000 | 171,200 | 8.56%         |
+
+  Scenario: I recalculate for next home
+    When I enter a house price of 260000
+    And I am a next home buyer
+    And I click next
+    And I see the stamp duty I will have to pay is "£2,950"
+    Then I reenter my house price with "426000"
+    And I click next again
+    And I see the stamp duty I will have to pay is "£11,900"
+    And I see the effective tax rate is "2.79%"
+
+  @javascript
+  Scenario: I recalculate for next home
+    When I enter a house price of 260000
+    And I am a next home buyer
+    And I click next
+    And I see the stamp duty I will have to pay is "£2,950"
+    Then I reenter my house price with "426000"
+    And I click next again
+    And I see the stamp duty I will have to pay is "£11,900"
+
+  Scenario Outline: Buy to let buyer
+    Given I am an additional or buy-to-let property buyer
+    When I enter a house price of <price>
+    And I click next
+    And I see the stamp duty I will have to pay is "£<duty>"
+    And I see the effective tax rate is "<effective tax>"
+
+    Examples:
+      | price   | duty    | effective tax |
+      | 35000   | 0       | 0.00%         |
+      | 180000  | 5,400   | 3.00%         |
+      | 260000  | 10,750  | 4.13%         |
+      | 500000  | 32,450  | 6.49%         |
+      | 900000  | 78,200  | 8.69%         |
+      | 1800000 | 201,200 | 11.18%        |

--- a/features/step_definitions/land_transaction_tax.rb
+++ b/features/step_definitions/land_transaction_tax.rb
@@ -1,0 +1,4 @@
+Given('I visit the land transaction tax page') do
+  @stamp_duty = UI::Pages::LandTransactionTax.new
+  @stamp_duty.load
+end

--- a/features/support/ui/pages/land_transaction_tax.rb
+++ b/features/support/ui/pages/land_transaction_tax.rb
@@ -1,0 +1,14 @@
+require_relative './stamp_duty'
+
+module UI
+  module Pages
+    class LandTransactionTax < UI::Pages::StampDuty
+      include DefaultLocale
+
+      set_url '/{locale}/mortgage_calculator/land-transaction-tax-calculator'
+      element :buyer_type, "form.step_one select[name='buyer_type']"
+      element :property_price, "form.step_one input[name='land_transaction_tax[price]']"
+      element :property_price_step_two, "form.step_two input[name='land_transaction_tax[price]']"
+    end
+  end
+end


### PR DESCRIPTION
[TP Card](https://moneyadviceservice.tpondemand.com/entity/8974-land-transaction-tax-calculator-stamp-duty)

## Context

The Land Transaction Tax calculator **for Wales** was developed already (refer to #329), The approach used to build this tool resulted in a lot of duplicated code across the Stamp Duty, Land & Buildings Transaction tax calculator and Land Transaction tax calculators.

This pr begins the refactoring by adding feature tests for the Land & Buildings Transaction tax calculator to facilitate the refactor.

## Observation

* Since there were already cucumber steps for the stamp duty in place, the only thing to do in the feature tests is to point them to the land and transaction tax instead.
* The first time buyer locale was removed from because this tool does not have the first time buyers option. And this was preventing for the dummy app to work since the dummy app raises error for translation missing.

After this the controllers, helpers and views could be refactored.

## Next Pull requests

- [x] Add feature tests for the Scotland calculator
- [x] Add feature tests for the Wales calculator
- [x] Refactor the Scotland and Wales controllers
- [x] Refactor the Scotland and Wales views