### PR TITLE
[DEV APPROVED] Refactor controllers of 8974 and 8798

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'mas-development_dependencies', '2.3.0.35'
 gem 'meta-tags'
 
 group :test, :development do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'byebug'
   gem 'rubocop', require: false
 end

--- a/app/controllers/mortgage_calculator/application_controller.rb
+++ b/app/controllers/mortgage_calculator/application_controller.rb
@@ -8,11 +8,11 @@ module MortgageCalculator
     helper_method :disable_responsiveness?
 
     protected
+
     def disable_responsiveness?
       return super if defined?(super)
 
       false
     end
   end
-
 end

--- a/app/controllers/mortgage_calculator/land_and_buildings_transaction_taxes_controller.rb
+++ b/app/controllers/mortgage_calculator/land_and_buildings_transaction_taxes_controller.rb
@@ -1,36 +1,7 @@
 module MortgageCalculator
-  class LandAndBuildingsTransactionTaxesController < ::MortgageCalculator::ApplicationController
-    CALCULATOR = MortgageCalculator::LandAndBuildingsTransactionTax
-    before_action :set_rates
-    def show
-      @lbtt = CALCULATOR.new
-    end
-
-    def create
-      @lbtt = CALCULATOR.new(
-        params.require(:land_and_buildings_transaction_tax)
-          .permit(:price, :buyer_type)
-          .symbolize_keys
-      )
-      unless @lbtt.valid?
-        render :show
-      end
-    end
-
-    private
-
-    def set_rates
-      @rates = CALCULATOR.banding_for(
-        CALCULATOR::STANDARD_BANDS
-      )
-    end
-
-    def category_id
-      'buying-a-home'
-    end
-
-    def tool_name
-      I18n.translate('land_and_buildings_transaction_tax.tool_name')
+  class LandAndBuildingsTransactionTaxesController < ::MortgageCalculator::TransactionTaxCalculatorController
+    def calculator
+      MortgageCalculator::LandAndBuildingsTransactionTax
     end
   end
 end

--- a/app/controllers/mortgage_calculator/land_transaction_taxes_controller.rb
+++ b/app/controllers/mortgage_calculator/land_transaction_taxes_controller.rb
@@ -1,36 +1,7 @@
 module MortgageCalculator
-  class LandTransactionTaxesController < ::MortgageCalculator::ApplicationController
-    CALCULATOR = MortgageCalculator::LandTransactionTax
-    before_action :set_rates
-    def show
-      @ltt = CALCULATOR.new
-    end
-
-    def create
-      @ltt = CALCULATOR.new(
-        params.require(:land_transaction_tax)
-        .permit(:price, :buyer_type)
-        .symbolize_keys
-      )
-      unless @ltt.valid?
-        render :show
-      end
-    end
-
-    private
-
-    def set_rates
-      @rates = CALCULATOR.banding_for(
-        CALCULATOR::STANDARD_BANDS
-      )
-    end
-
-    def category_id
-      'buying-a-home'
-    end
-
-    def tool_name
-      I18n.translate('land_transaction_tax.tool_name')
+  class LandTransactionTaxesController < ::MortgageCalculator::TransactionTaxCalculatorController
+    def calculator
+      MortgageCalculator::LandTransactionTax
     end
   end
 end

--- a/app/controllers/mortgage_calculator/transaction_tax_calculator_controller.rb
+++ b/app/controllers/mortgage_calculator/transaction_tax_calculator_controller.rb
@@ -1,0 +1,37 @@
+module MortgageCalculator
+  class TransactionTaxCalculatorController < MortgageCalculator::ApplicationController
+    def resource
+      @resource ||= calculator.new
+    end
+    helper_method :resource
+
+    def create
+      @resource = calculator.new(calculator_params)
+
+      render :show if @resource.invalid?
+    end
+
+    def standard_rates
+      calculator.banding_for(calculator::STANDARD_BANDS)
+    end
+    helper_method :standard_rates
+
+    private
+
+    def category_id
+      'buying-a-home'
+    end
+    helper_method :category_id
+
+    def calculator_params
+      params
+        .require(calculator_params_key)
+        .permit(:price, :buyer_type)
+        .symbolize_keys
+    end
+
+    def calculator_params_key
+      self.class.name.demodulize.underscore.gsub('_controller', '').singularize
+    end
+  end
+end

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_bands_table.html.erb
@@ -7,7 +7,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @rates.each do |rate| %>
+    <% standard_rates.each do |rate| %>
       <tr>
         <td class="mortgagecalc__table__price"><%= band(rate[:start], rate[:end]) %></td>
         <td class="mortgagecalc__table__rate"><%= rate[:rate] %>%</td>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_form_step1.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @lbtt, url: land_and_buildings_transaction_tax_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_one stamp-duty__step-one', novalidate: '' } do |f| %>
+<%= form_for resource, url: land_and_buildings_transaction_tax_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_one stamp-duty__step-one', novalidate: '' } do |f| %>
 
   <%= f.label :buyer_type, class: 'stamp-duty__buyer-type' do %>
     <%= t('land_and_buildings_transaction_tax.select.label') %>
@@ -27,7 +27,7 @@
     <span class="stamp-duty__input-wrapper stamp-duty__input-wrapper--inline">
       <span class="stamp-duty__input--unit">£</span>
       <%= f.text_field :price,
-      :value => @lbtt.price_formatted,
+      :value => resource.price_formatted,
       "autofocus" => '',
       "ng-model" => "stampDuty.propertyPrice",
       "placeholder" => "0",

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_form_step2.html.erb
@@ -1,5 +1,5 @@
 <div class="stamp-duty__calculator-column">
-  <%= form_for @lbtt, url: land_and_buildings_transaction_tax_path, html: { id: 'update_stamp_duty', name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
+  <%= form_for resource, url: land_and_buildings_transaction_tax_path, html: { id: 'update_stamp_duty', name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
     <div class="form__item stamp-duty__form">
       <%= f.label :price, class: 'stamp-duty__input-description' %>
       <div class="visually-hidden"
@@ -10,7 +10,7 @@
       <span class="stamp-duty__input-wrapper">
         <span class="stamp-duty__input--unit">£</span>
         <%= f.text_field :price,
-                         :value => @lbtt.price_formatted,
+                         :value => resource.price_formatted,
                          class: 'stamp-duty__input dynamic-slider-property',
                          "ng-model" => "stampDuty.propertyPrice",
                          "placeholder" => "0.00",
@@ -48,7 +48,7 @@
 
   <% end %>
 
-  <%= render 'stamp_duty_to_pay_panel' if @lbtt.valid? %>
+  <%= render 'stamp_duty_to_pay_panel' if resource.valid? %>
 
   <div class="">
     <h2 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h2>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
@@ -1,7 +1,7 @@
 <div class="stamp-duty__results">
   <div class="stamp-duty__results-heading" aria-live="polite" aria-atomic="true">
     <div ng-hide="js">
-      <% key = @lbtt.second_home? ? 'second_title' : 'title' %>
+      <% key = resource.second_home? ? 'second_title' : 'title' %>
       <%= I18n.t("land_and_buildings_transaction_tax.results.#{key}") %>
     </div>
     <div class="hidden-unless-js">
@@ -14,7 +14,7 @@
     </div>
 
     <span ng-hide="js">
-      <%= number_to_currency @lbtt.tax_due_formatted %>
+      <%= number_to_currency resource.tax_due_formatted %>
     </span>
     <span class="rendered-from-js">
       {{ stampDuty.cost() | customCurrency:"£" }}
@@ -24,7 +24,7 @@
   <p ng-hide="js" class="stamp-duty__results-tax-rate ng-hide">
     <%= I18n.t('land_and_buildings_transaction_tax.results.sentence',
               percentage: number_to_percentage(
-                @lbtt.percentage_tax, precision: 2
+                resource.percentage_tax, precision: 2
               )
         )
     %>

--- a/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/show.html.erb
+++ b/app/views/mortgage_calculator/land_and_buildings_transaction_taxes/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
-  <% @lbtt.errors.full_messages.each do |message| %>
+  <% resource.errors.full_messages.each do |message| %>
     <span style="color:red;"><%= message %></span>
   <% end %>
   <div wizard on-finish="finishedWizard()" hide-indicators='true'>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_bands_table.html.erb
@@ -7,7 +7,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @rates.each do |rate| %>
+    <% standard_rates.each do |rate| %>
       <tr>
         <td class="mortgagecalc__table__price"><%= band(rate[:start], rate[:end]) %></td>
         <td class="mortgagecalc__table__rate"><%= rate[:rate] %>%</td>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_form_step1.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @ltt, url: land_transaction_tax_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_one stamp-duty__step-one', novalidate: '' } do |f| %>
+<%= form_for resource, url: land_transaction_tax_path, html: { name: 'stamp_duty_form', role: 'form', class: 'form step_one stamp-duty__step-one', novalidate: '' } do |f| %>
 
   <%= f.label :buyer_type, class: 'stamp-duty__buyer-type' do %>
     <%= t('land_transaction_tax.select.label') %>
@@ -27,7 +27,7 @@
     <span class="stamp-duty__input-wrapper stamp-duty__input-wrapper--inline">
       <span class="stamp-duty__input--unit">£</span>
       <%= f.text_field :price,
-      :value => @ltt.price_formatted,
+      :value => resource.price_formatted,
       "autofocus" => '',
       "ng-model" => "stampDuty.propertyPrice",
       "placeholder" => "0",

--- a/app/views/mortgage_calculator/land_transaction_taxes/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_form_step2.html.erb
@@ -1,5 +1,5 @@
 <div class="stamp-duty__calculator-column">
-  <%= form_for @ltt, url: land_transaction_tax_path, html: { id: 'update_stamp_duty', name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
+  <%= form_for resource, url: land_transaction_tax_path, html: { id: 'update_stamp_duty', name: 'stamp_duty_form', role: 'form', class: 'step_two', 'ng-submit' => 'preventFormSubmission($event)', novalidate: '' } do |f| %>
     <div class="form__item stamp-duty__form">
       <%= f.label :price, class: 'stamp-duty__input-description' %>
       <div class="visually-hidden"
@@ -10,7 +10,7 @@
       <span class="stamp-duty__input-wrapper">
         <span class="stamp-duty__input--unit">£</span>
         <%= f.text_field :price,
-                         :value => @ltt.price_formatted,
+                         :value => resource.price_formatted,
                          class: 'stamp-duty__input dynamic-slider-property',
                          "ng-model" => "stampDuty.propertyPrice",
                          "placeholder" => "0.00",
@@ -48,7 +48,7 @@
 
   <% end %>
 
-  <%= render 'stamp_duty_to_pay_panel' if @ltt.valid? %>
+  <%= render 'stamp_duty_to_pay_panel' if resource.valid? %>
 
   <div class="">
     <h2 class="mortgagecalc__heading stamp-duty__have-you-tried"><%= t("stamp_duty.next_steps.have_you_tried.title") %></h2>

--- a/app/views/mortgage_calculator/land_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_stamp_duty_to_pay_panel.html.erb
@@ -1,7 +1,7 @@
 <div class="stamp-duty__results">
   <div class="stamp-duty__results-heading" aria-live="polite" aria-atomic="true">
     <div ng-hide="js">
-      <% key = @ltt.second_home? ? 'second_title' : 'title' %>
+      <% key = resource.second_home? ? 'second_title' : 'title' %>
       <%= I18n.t("land_transaction_tax.results.#{key}") %>
     </div>
     <div class="hidden-unless-js">
@@ -14,7 +14,7 @@
     </div>
 
     <span ng-hide="js">
-      <%= number_to_currency @ltt.tax_due_formatted %>
+      <%= number_to_currency resource.tax_due_formatted %>
     </span>
     <span class="rendered-from-js">
       {{ stampDuty.cost() | customCurrency:"£" }}
@@ -24,7 +24,7 @@
   <p ng-hide="js" class="stamp-duty__results-tax-rate ng-hide">
     <%= I18n.t('land_transaction_tax.results.sentence',
               percentage: number_to_percentage(
-                @ltt.percentage_tax, precision: 2
+                resource.percentage_tax, precision: 2
               )
         )
     %>

--- a/app/views/mortgage_calculator/land_transaction_taxes/show.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
-  <% @ltt.errors.full_messages.each do |message| %>
+  <% resource.errors.full_messages.each do |message| %>
     <span style="color:red;"><%= message %></span>
   <% end %>
   <div wizard on-finish="finishedWizard()" hide-indicators='true'>

--- a/spec/controllers/land_and_buildings_transaction_taxes_controller_spec.rb
+++ b/spec/controllers/land_and_buildings_transaction_taxes_controller_spec.rb
@@ -4,6 +4,48 @@ module MortgageCalculator
   describe LandAndBuildingsTransactionTaxesController do
     routes { MortgageCalculator::Engine.routes }
 
+    describe '#calculator' do
+      it 'returns land and buildings transaction tax' do
+        expect(controller.calculator).to be(
+          MortgageCalculator::LandAndBuildingsTransactionTax
+        )
+      end
+    end
+
+    describe '#standard_rates' do
+      it 'returns the rates for each band' do
+        expect(controller.standard_rates).to eq(
+          [
+            {
+              start: 0,
+              end: 145_000,
+              rate: 0
+            },
+            {
+              start: 145_000.01,
+              end: 250_000,
+              rate: 2
+            },
+            {
+              start: 250_000.01,
+              end: 325_000,
+              rate: 5
+            },
+            {
+              start: 325_000.01,
+              end: 750_000,
+              rate: 10
+            },
+            {
+              start: 750_000.01,
+              end: nil,
+              rate: 12
+            }
+          ]
+        )
+      end
+    end
+
     describe '#show' do
       it 'responds with 200' do
         get :show
@@ -28,4 +70,3 @@ module MortgageCalculator
     end
   end
 end
-

--- a/spec/controllers/land_transaction_taxes_controller_spec.rb
+++ b/spec/controllers/land_transaction_taxes_controller_spec.rb
@@ -4,6 +4,53 @@ module MortgageCalculator
   describe LandTransactionTaxesController do
     routes { MortgageCalculator::Engine.routes }
 
+    describe '#calculator' do
+      it 'returns land and buildings transaction tax' do
+        expect(controller.calculator).to be(
+          MortgageCalculator::LandTransactionTax
+        )
+      end
+    end
+
+    describe '#standard_rates' do
+      it 'returns the rates for each band' do
+        expect(controller.standard_rates).to eq(
+          [
+            {
+              start: 0,
+              end: 180_000,
+              rate: 0
+            },
+            {
+              start: 180000.01,
+              end: 250_000,
+              rate: 3.5
+            },
+            {
+              start: 250_000.01,
+              end: 400_000,
+              rate: 5
+            },
+            {
+              start: 400_000.01,
+              end: 750_000,
+              rate: 7.5
+            },
+            {
+              start: 750_000.01,
+              end: 1_500_000,
+              rate: 10
+            },
+            {
+              start: 1_500_000.01,
+              end: nil,
+              rate: 12
+            }
+          ]
+        )
+      end
+    end
+
     describe '#show' do
       it 'responds with 200' do
         get :show


### PR DESCRIPTION
[TP Card](https://moneyadviceservice.tpondemand.com/entity/8798-land-and-buildings-transaction-tax-scotland)
[TP Card](https://moneyadviceservice.tpondemand.com/entity/8974-land-transaction-tax-calculator-stamp-duty)

## Context

This is the first step of refactoring the calculators.

 I create a parent class called TransactionTaxCalculator which
 will be responsible for handling the objects of land and buildings and transaction tax for Scotland and land transaction tax for Wales.

 Because every instance variable had it your own name  (e.g @stamp_duty, @lbtt and @ltt) and each of this names  is used on the view I created the helper method called  "resource" which will return the instance of the calculator of the page.

This will support refactoring the duplicated views later.

**Rates** now uses the name of "standard_rates" on taxes controller

The rates name is returning nil even used as helper_method.
So renaming to standard_rates fixes the issue.
Add as helper method so we could remove the land and buildings
transaction tax controller calculator duplicated views

I also add the better errors gem because was easier to spot about the state of refactoring to make the tests pass.

## Next Pull requests

- [x] Add feature tests for the Scotland calculator
- [x] Add feature tests for the Wales calculator
- [x] Refactor the Scotland and Wales controllers
- [x] Refactor the Scotland and Wales views