### PR TITLE
[DEV APPROVED] 8974 add welsh translations

### DIFF
--- a/config/locales/land_transaction_tax.cy.yml
+++ b/config/locales/land_transaction_tax.cy.yml
@@ -1,0 +1,72 @@
+cy:
+  land_transaction_tax:
+    meta:
+      title: "Cyfrifiannell Treth Trafodiadau Tir"
+      description: "Cyfrifwch y Dreth Trafodiadau Tir ar eich eiddo preswyl yng Nghymru"
+      canonical_url: "https://www.moneyadviceservice.org.uk/cy/tools/prynu-ty/cyfrifiannell-treth-trafodion-tir-ac-adeiladau"
+    tooltip_show: sioe help
+    tooltip_hide: cuddio cymorth
+    heading: "Cyfrifiannell Treth Trafodiadau Tir"
+    heading_results: "Cyfrifiannell Treth Trafodiadau Tir - Eich canlyniadau"
+    title: "Cyfrifwch y Dreth Trafodion Tir ac Adeiladau ar eich eiddo preswyl yn yr Alban"
+    next: "Nesaf"
+    select:
+      label: "Rwy'n"
+      option_prompt: "dewiswch opsiwn"
+      option_isNextHome: "prynu fy nghartref nesaf"
+      option_isSecondHome: "prynu eiddo atodol neu eiddo prynu-i-osod"
+      tooltip_html: "Bydd unrhyw un sy’n prynu cartref ychwanegol gan gynnwys eiddo prynu i osod dros £40,000 mewn gwerth yn gorfod talu ffi ychwanegol o 3% ar ben pob band Treth Trafodiadau Tir."
+    recalculate: Ailgyfrifo
+    how_calculated_toggle: "Sut y cyfrifir hyn?"
+    elsewhere:
+      title: "Prynu yn Lloegr, Gogledd Iwerddon neu'r Alban?"
+      body: "Os ydych chi'n prynu yn unrhyw un o'r gwledydd hyn, yna defnyddiwch y gyfrifiannell briodol i gyfrifo faint fyddwch chi'n ei dalu:"
+      england_ni:
+        title: "Cyfrifwch Dreth Stamp yng Nghymru, Lloegr neu Ogledd Iwerddon"
+        body: "Rhaid talu Treth Stamp (SDLT) ar eiddo yn Lloegr a Gogledd Iwerddon o hyd"
+        link: "/cy/tools/prynu-ty/cyfrifiannell-treth-stamp"
+      scotland:
+        title: 'Cyfrifwch Dreth Trafodiadau Tir ac Adeiladau ar gyfer yr Alban'
+        body: 'Cyfrifwch Dreth Trafodiadau Tir ac Adeiladau ar gyfer yr Alban'
+        link: "/en/tools/house-buying/land-and-buildings-transaction-tax-calculator"
+    how_calculated_toggle: "Sut y cyfrifir hyn?"
+    how_calculated: "Telir Treth Trafodiadau Tir (LTT) ar gyfraddau gwahanol, yn ddibynnol ar y band mae’r pris prynu ynddo. Er enghraifft, ni fyddai rhywun yn prynu eiddo am £280,000 yn talu treth ar werth yr eiddo hyd at £180,000, 3.5% o dreth ar werth yr eiddo rhwng £180,001 a £250,000 a 5% ar werth yr eiddo rhwng £250,001 a £280,000. Yn yr achos hwn, byddai cyfanswm yr atebolrwydd treth ar gyfer Treth Trafodiadau Tir ac Adeiladau (LTT) yn £3,950 gan roi cyfradd dreth effeithiol o 1.41% (cyfartaledd cyfradd canrannol y dreth a dalwyd)."
+    how_calculated_additional: "Bydd unrhyw un sy’n prynu ail gartref, gan gynnwys eiddo prynu-i-osod, yn talu 3% ychwanegol ar ben y band cyfradd safonol. Yn yr enghraifft hon, byddai hynny'n cynrychioli £8,400 ychwanegol, sy'n golygu y byddai cyfanswm y dreth stamp yn £12,350 gan roi cyfradd treth effeithiol o 4.41%."
+    how_calculated_extra: "* Nid yw eiddo dan %{amount} yn destun yr Atodiad Annedd Atodol ar gyfer ail gartref"
+    describe_price_field: "Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn."
+    activemodel:
+      attributes:
+        mortgage_calculator/land_transaction_tax:
+          price: "Pris eiddo:"
+    results:
+      title: "Y Treth Trafodion Tir ac Adeiladau i'w thalu yw"
+      second_title: "Y Treth Trafodion Tir ac Adeiladau i'w thalu yw"
+      sentence: "Y gyfradd dreth effeithiol yw %{percentage}"
+      sentence_prefix: "Y gyfradd dreth effeithiol yw"
+      sentence_suffix: "%"
+      click_to_expand: Cliciwch i ehangu
+    table:
+      property_price_header: "Pris prynu’r eiddo"
+      rate_header: "Cyfradd Treth Trafodion Tir ac Adeiladau (LBTT)"
+      extra_rate_header: "Atodiad Prynu-i-osod / Annedd Atodol (ADS)*"
+      max: "%{value}+"
+    next_steps:
+      learn_more:
+        title: "A wyddech chi?"
+        tip_1: "Rhaid i chi dalu Treth Trafodiadau Tir cyn pen 30 diwrnod ar ôl prynu eiddo. Os ydych yn defnyddio cyfreithiwr i gwblhau’r trawsgludo, bydd fel arfer yn trefnu’r taliad ar eich rhan."
+        link_1:
+          title: "Treth Trafodiadau Tir – Popeth y mae angen i chi ei wybod"
+          url: "/cy/articles/treth-trafodiadau-tir-popeth-y-mae-angen-i-chi-ei-wybod"
+      find_out_more:
+        title: "Darganfyddwch fwy"
+        tips:
+          - copy_html: "Costau ymlaen llaw prynu cartref"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
+          - copy_html: "Ffioedd a chostau morgais"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/cipolwg-ar-ffioedd-a-chostau-syn-gysylltiedig-a-morgeisi"
+          - copy_html: "Costau diwrnod symud"
+            url: "https://www.moneyadviceservice.org.uk/cy/articles/cynllunio-ar-gyfer-cost-diwrnod-symud"
+      have_you_tried:
+        title: 'Rhowch gynnig ar?'
+        mortgage_calculator: "Cyfrifiannell morgais"
+        mortgage_affordability_calculator: "Cyfrifiannell fforddiadwyedd"

--- a/config/locales/land_transaction_tax.en.yml
+++ b/config/locales/land_transaction_tax.en.yml
@@ -6,10 +6,9 @@ en:
       canonical_url: "https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-transaction-tax-calculator"
     tooltip_show: show help
     tooltip_hide: hide help
-    tool_name: "land-transaction-tax-calculator"
     heading: "Land Transaction Tax (LTT) calculator"
     heading_results: "Land Transaction Tax (LTT) calculator - Your Results"
-    title: "Calculate the Land and Buildings Transaction Tax on your residential property in Wales"
+    title: "Calculate the Land Transaction Tax on your residential property in Wales"
     next: Next
     select:
       label: I am
@@ -39,15 +38,15 @@ en:
         mortgage_calculator/land_transaction_tax:
           price: "Property Price:"
     results:
-      title: "Land and Buildings Transaction Tax to pay is"
-      second_title: "Land and Buildings Transaction Tax on your additional property"
+      title: "Land Transaction Tax to pay is"
+      second_title: "Land Transaction Tax on your additional property"
       sentence: "The effective tax rate is %{percentage}"
       sentence_prefix: "The effective tax rate is"
       sentence_suffix: "%"
       click_to_expand: Click to expand.
     table:
       property_price_header: "Purchase price of property"
-      rate_header: "Rate of Land and Buildings Transaction Tax"
+      rate_header: "Rate of Land Transaction Tax"
       extra_rate_header: "Buy to Let/Additional Home rate *"
       max: "%{value}+"
     next_steps:

--- a/spec/dummy/app/views/home/index.html.erb
+++ b/spec/dummy/app/views/home/index.html.erb
@@ -11,6 +11,16 @@
 </ul>
 
 <ul>
+  <li><%= link_to "Land and Buildings Transaction Tax", mortgage_calculator.land_and_buildings_transaction_tax_path %></li>
+  <li><%= link_to "Land and Buildings Transaction Tax (Welsh)", mortgage_calculator.land_and_buildings_transaction_tax_path(locale: :cy) %></li>
+</ul>
+
+<ul>
+  <li><%= link_to "Land Transaction Tax", mortgage_calculator.land_transaction_tax_path %></li>
+  <li><%= link_to "Land Transaction Tax (Welsh)", mortgage_calculator.land_transaction_tax_path(locale: :cy) %></li>
+</ul>
+
+<ul>
   <li><%= link_to "Mortgage Affordability Calculator", mortgage_calculator.affordability_path %></li>
   <li><%= link_to "Mortgage Affordability Calculator (Welsh)", mortgage_calculator.affordability_cy_path(locale: :cy) %></li>
 </ul>


### PR DESCRIPTION
[TP](https://moneyadviceservice.tpondemand.com/entity/8974-land-transaction-tax-calculator-stamp-duty)

Adding Welsh translations to the Land transaction tax calculator for Wales and fixing some english names for the tool.

I also added both of the tools (lbtt for Scotand and ltt for Wales) on the dummy root page so everyone that clones the repo did not need to search which url is for each calculator.