### PR TITLE
[DEV APPROVED] - TP: 9104, Comment: Corrects subtitle on calculator

### DIFF
--- a/config/locales/land_transaction_tax.cy.yml
+++ b/config/locales/land_transaction_tax.cy.yml
@@ -9,7 +9,7 @@ cy:
     heading: "Cyfrifiannell Treth Trafodiadau Tir"
     heading_description: "Mae Treth Stamp wedi ei ddisodli gan y Dreth Trafodiadau Tir (LTT) ar gyfer eiddo a brynir yng Nghymru. Bydd LTT yn berthnasol i eiddo preswyl sy'n costio dros £180,000. Gallwch ddefnyddio’r gyfrifiannell hon i ganfod faint o Dreth Trafodiadau Tir fydd rhaid i chi dalu. Gallwch hefyd gyfrifo cost LTT ar unrhyw eiddo atodol a brynwch dros £40,000, fel prynu i osod neu ail gartref, ble codir tâl atodol o 3% arnoch."
     heading_results: "Cyfrifiannell Treth Trafodiadau Tir - Eich canlyniadau"
-    title: "Cyfrifwch y Dreth Trafodion Tir ac Adeiladau ar eich eiddo preswyl yn yr Alban"
+    title: "Cyfrifwch y Dreth Trafodiadau Tir ar eich eiddo preswyl yng Nghymru"
     next: "Nesaf"
     select:
       label: "Rwy'n"

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 3
     MINOR = 1
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
[TP9104](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=userstory/9057&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/9104)

Corrects a wrong translation in the subtitle on the landing page of the LTT tool: 

Current: 

![image](https://user-images.githubusercontent.com/6080548/38361437-470ccb12-38c5-11e8-8fba-27a7958e2ef4.png)

Updated: 

![image](https://user-images.githubusercontent.com/6080548/38361439-4e86bca4-38c5-11e8-98fb-88b69e3b05b4.png)
