### PR TITLE
[DEV APPROVED] 9255 results rounding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,15 +19,17 @@ end
 
 group :test do
   gem 'brakeman', require: false
-  gem 'capybara'
+  gem 'capybara', '2.18.0'
   gem 'coffee-rails'
   gem 'cucumber', '~> 3.0.1'
+  gem 'cucumber-rails', '1.6.0'
   gem 'mas-templating'
   gem 'rspec-its'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 3.0'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
+  gem 'site_prism', '2.11'
   gem 'sqlite3'
   gem 'tzinfo-data'
 end

--- a/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
@@ -69,7 +69,11 @@ App.factory('StampDuty', function() {
           totalTax += this.propertyPrice * (this.secondHomeTaxRate / 100);
         }
 
-        return Math.floor(totalTax);
+        if (cfg.tool === 'ltt') {
+          return totalTax;
+        } else {
+          return Math.floor(totalTax);
+        }
       },
 
       totalPurchase : function() {

--- a/app/helpers/mortgage_calculator/land_transaction_taxes_helper.rb
+++ b/app/helpers/mortgage_calculator/land_transaction_taxes_helper.rb
@@ -19,6 +19,7 @@ module MortgageCalculator
     def calculator_config_json
       calculator = MortgageCalculator::LandTransactionTax
       {
+        tool: 'ltt',
         standard: calculator::STANDARD_BANDS,
         second_home_tax_rate: calculator::SECOND_HOME_ADDITIONAL_TAX,
         second_home_threshold: calculator::SECOND_HOME_THRESHOLD

--- a/app/models/mortgage_calculator/land_transaction_tax.rb
+++ b/app/models/mortgage_calculator/land_transaction_tax.rb
@@ -18,5 +18,17 @@ module MortgageCalculator
     def bands_to_use
       STANDARD_BANDS
     end
+
+    def tax_for_band(band_start, band_end, rate)
+      return 0 if price < band_start
+      rate += SECOND_HOME_ADDITIONAL_TAX if second_home_taxable?
+      upper_limit = price_in_band?(band_end) ? price : band_end
+      amount_to_tax = upper_limit - band_start.floor
+      amount_to_tax * rate / 100
+    end
+
+    def format_currency(value, precision = 2)
+      number_to_currency(value, unit: '', precision: precision)
+    end
   end
 end

--- a/app/models/mortgage_calculator/tax_calculator.rb
+++ b/app/models/mortgage_calculator/tax_calculator.rb
@@ -19,12 +19,16 @@ module MortgageCalculator
       self.buyer_type = buyer_type
     end
 
-    %i[price tax_due total_due].each do |field|
-      define_method "#{field}_formatted" do
-        number_to_currency(
-          public_send(field).presence || 0, unit: '', precision: 0
-        )
-      end
+    def price_formatted
+      format_currency(price || 0)
+    end
+
+    def tax_due_formatted
+      format_currency(tax_due || 0)
+    end
+
+    def total_due_formatted
+      format_currency(total_due || 0)
     end
 
     def tax_due
@@ -82,6 +86,10 @@ module MortgageCalculator
 
     def price_in_band?(band_end)
       band_end.nil? || price <= band_end
+    end
+
+    def format_currency(value, precision = 0)
+      number_to_currency(value, unit: '', precision: precision)
     end
   end
 end

--- a/features/land_transaction_tax_calculator.feature
+++ b/features/land_transaction_tax_calculator.feature
@@ -14,14 +14,15 @@ Feature: Land Transaction Tax Calculator
     And I see the effective tax rate is "<effective tax>"
 
   Examples:
-    | price   | duty    | effective tax |
-    | 39000   | 0       | 0.00%         |
-    | 40000   | 0       | 0.00%         |
-    | 179000  | 0       | 0.00%         |
-    | 260000  | 2,950   | 1.13%         |
-    | 450000  | 13,700  | 3.04%         |
-    | 800000  | 41,200  | 5.15%         |
-    | 2000000 | 171,200 | 8.56%         |
+    | price   | duty       | effective tax |
+    | 39000   | 0          | 0.00%         |
+    | 40000   | 0          | 0.00%         |
+    | 179000  | 0          | 0.00%         |
+    | 260000  | 2,950      | 1.13%         |
+    | 333333  | 6,616      | 1.98%         |
+    | 467895  | 15,042     | 3.21%         |
+    | 800000  | 41,200     | 5.15%         |
+    | 2000000 | 171,200    | 8.56%         |
 
   @javascript
   Scenario Outline: tax for next home
@@ -31,14 +32,15 @@ Feature: Land Transaction Tax Calculator
     Then I see the stamp duty I will have to pay is "£<duty>"
 
   Examples:
-    | price   | duty    | effective tax |
-    | 39000   | 0       | 0.00%         |
-    | 40000   | 0       | 0.00%         |
-    | 179000  | 0       | 0.00%         |
-    | 260000  | 2,950   | 1.13%         |
-    | 450000  | 13,700  | 3.04%         |
-    | 800000  | 41,200  | 5.15%         |
-    | 2000000 | 171,200 | 8.56%         |
+    | price   | duty       | effective tax |
+    | 39000   | 0          | 0.00%         |
+    | 40000   | 0          | 0.00%         |
+    | 179000  | 0          | 0.00%         |
+    | 260000  | 2,950      | 1.13%         |
+    | 333333  | 6,616.65   | 1.98%         |
+    | 467895  | 15,042.13  | 3.21%         |
+    | 800000  | 41,200     | 5.15%         |
+    | 2000000 | 171,200    | 8.56%         |
 
   Scenario: I recalculate for next home
     When I enter a house price of 260000
@@ -55,10 +57,10 @@ Feature: Land Transaction Tax Calculator
     When I enter a house price of 260000
     And I am a next home buyer
     And I click next
-    And I see the stamp duty I will have to pay is "£2,950"
-    Then I reenter my house price with "426000"
+    And I see the stamp duty I will have to pay is "£2,950.00"
+    Then I reenter my house price with "333333"
     And I click next again
-    And I see the stamp duty I will have to pay is "£11,900"
+    And I see the stamp duty I will have to pay is "£6,616.65"
 
   Scenario Outline: Buy to let buyer
     Given I am an additional or buy-to-let property buyer
@@ -68,10 +70,11 @@ Feature: Land Transaction Tax Calculator
     And I see the effective tax rate is "<effective tax>"
 
     Examples:
-      | price   | duty    | effective tax |
-      | 35000   | 0       | 0.00%         |
-      | 180000  | 5,400   | 3.00%         |
-      | 260000  | 10,750  | 4.13%         |
-      | 500000  | 32,450  | 6.49%         |
-      | 900000  | 78,200  | 8.69%         |
-      | 1800000 | 201,200 | 11.18%        |
+      | price   | duty     | effective tax |
+      | 35000   | 0        | 0.00%         |
+      | 135588  | 4,067    | 3.00%         |
+      | 180000  | 5,400    | 3.00%         |
+      | 260000  | 10,750   | 4.13%         |
+      | 500000  | 32,450   | 6.49%         |
+      | 900000  | 78,200   | 8.69%         |
+      | 1800000 | 201,200  | 11.18%        |

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,8 +1,8 @@
 module MortgageCalculator
   module Version
     MAJOR = 3
-    MINOR = 1
-    PATCH = 1
+    MINOR = 2
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
[TP9255](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/9255)

The purpose of this PR is to display the Stamp Duty payable in the results section of the tool differently in the Wales version (Land Transaction Tax) than in the other versions, specifically this should be be shown to the nearest penny rather than rounded down to the nearest pound as on the other calculators. 

This calculation is made within a JavaScript scenario and non-JavaScript scenario. 

### Current: 

![image](https://user-images.githubusercontent.com/6080548/42041007-e50309c0-7ae8-11e8-8b09-887666d680eb.png)

### Updated: 

![image](https://user-images.githubusercontent.com/6080548/42041027-ee6281da-7ae8-11e8-8af2-68bd30565dd6.png)
