### PR TITLE
9302 Added target blank to stamp duty did you know links

### DIFF
--- a/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
+++ b/app/views/mortgage_calculator/stamp_duties/_form_step2.html.erb
@@ -71,7 +71,7 @@
     <span class="callout__icon" aria-hidden="true">?</span>
     <h2 class="stamp-duty__info-subheading callout__heading"><%= I18n.t("stamp_duty.next_steps.learn_more.title") %></h2>
     <p class="stamp-duty__info-tip"><%= I18n.t("stamp_duty.next_steps.learn_more.tip_1") %></p>
-    <p><a class="stamp-duty__info-tip-link" href="<%= I18n.t("stamp_duty.next_steps.learn_more.link_1.url") %>"><%= I18n.t("stamp_duty.next_steps.learn_more.link_1.title") %></a>
+    <p><a class="stamp-duty__info-tip-link" href="<%= I18n.t("stamp_duty.next_steps.learn_more.link_1.url") %>" target="_blank"><%= I18n.t("stamp_duty.next_steps.learn_more.link_1.title") %></a>
   </div>
 
   <h2 class="mortgagecalc__subheading"><%= I18n.t("stamp_duty.next_steps.find_out_more.title") %>:</h2>

--- a/app/views/mortgage_calculator/transaction_tax_calculator/_results_recalculation_form.html.erb
+++ b/app/views/mortgage_calculator/transaction_tax_calculator/_results_recalculation_form.html.erb
@@ -88,7 +88,7 @@
     <p class="stamp-duty__info-tip">
       <%= I18n.t("#{i18n_locale_namespace}.next_steps.learn_more.tip_1") %>
     </p>
-    <p><a class="stamp-duty__info-tip-link" href="<%= I18n.t("#{i18n_locale_namespace}.next_steps.learn_more.link_1.url") %>"><%= I18n.t("#{i18n_locale_namespace}.next_steps.learn_more.link_1.title") %></a>
+    <p><a class="stamp-duty__info-tip-link" href="<%= I18n.t("#{i18n_locale_namespace}.next_steps.learn_more.link_1.url") %>" target="_blank"><%= I18n.t("#{i18n_locale_namespace}.next_steps.learn_more.link_1.title") %></a>
   </div>
 
   <h2 class="mortgagecalc__subheading"><%= I18n.t("#{i18n_locale_namespace}.next_steps.find_out_more.title") %>:</h2>


### PR DESCRIPTION
[TP9302](https://moneyadviceservice.tpondemand.com/entity/9302-stamp-duty-calculator-and-scotland-and)

This PR adds target blank to the stamp duty did you know links so they open in a new tab, this also updates LBTT and LTT as these use the same views.