### PR TITLE
[DEV APPROVED] 9323 Mortgage affordability calculator tooltip bug

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/directives/tooltip.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/directives/tooltip.js
@@ -7,7 +7,7 @@ App.directive('ngTooltip', function() {
       '$scope', '$element', '$attrs', '$parse', function($scope, $element, $attrs, $parse) {
         var tooltipID = $element.attr('id'),
             $inputTarget = $('[aria-describedby="' + tooltipID + '"]'),
-            hiddenClass = 'tooltip--hidden',
+            hiddenClass = 'is-hidden',
             persistOnScreen = $element.attr('data-tooltip-persist'),
             debounceTimer;
 

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 3
     MINOR = 2
-    PATCH = 1
+    PATCH = 2
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
There was a bug where the tooltip information was constantly showing, and overlapping other tooltips.
This PR changes the hidden class to use the site wide is-hidden class on the tooltip so that the component works correctly and hides when it has the hidden class.

### Screenshots
**Before:**
<img width="885" alt="screen shot 2018-07-23 at 10 38 43" src="https://user-images.githubusercontent.com/3898629/43069317-adc648ca-8e64-11e8-8d54-f50eb2d095cd.png">
**After:**
<img width="894" alt="screen shot 2018-07-23 at 10 39 10" src="https://user-images.githubusercontent.com/3898629/43069318-addbf36e-8e64-11e8-83d8-7d3b40cf20c3.png">

