### PR TITLE
[DEV APPROVED] Adds JQuery 3.3 and JQuery Migrate

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/application.js
+++ b/app/assets/javascripts/mortgage_calculator/application.js
@@ -10,7 +10,8 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
-//= require jquery
+//= require jquery/dist/jquery
+//= require jquery-migrate/jquery-migrate
 //= require angular
 //= require angular-mocks
 //= require jquery-ui-mod

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -7,6 +7,11 @@
   "dependencies": {
     "dough": "<%= gem_path('dough-ruby') %>",
     "yeast": "^1.0.0",
-    "jquery-waypoints": "2.0.*"
+    "jquery": "3.3.*",
+    "jquery-waypoints": "2.0.*",
+    "jquery-migrate": "3.0.*"
+  },
+  "resolutions": {
+    "jquery": "3.3.*"
   }
 }

--- a/lib/mortgage_calculator/engine.rb
+++ b/lib/mortgage_calculator/engine.rb
@@ -1,6 +1,5 @@
 require 'modernizr-rails'
 require 'sass-rails'
-require 'jquery-rails'
 require 'angularjs-rails'
 require 'underscore-rails'
 require 'mas/fonts'

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 3
-    MINOR = 5
+    MINOR = 6
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')

--- a/mortgage_calculator.gemspec
+++ b/mortgage_calculator.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 4", "< 5"
   s.add_dependency "sass-rails"
   s.add_dependency "modernizr-rails"
-  s.add_dependency "jquery-rails"
   s.add_dependency "angularjs-rails", '~> 1.2.18'
   s.add_dependency "underscore-rails"
   s.add_dependency "dough-ruby", "~> 5.0"

--- a/mortgage_calculator.gemspec
+++ b/mortgage_calculator.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency "modernizr-rails"
   s.add_dependency "angularjs-rails", '~> 1.2.18'
   s.add_dependency "underscore-rails"
-  s.add_dependency "dough-ruby", "~> 5.0"
+  s.add_dependency "dough-ruby", "~> 5.36"
   s.add_dependency "mas-fonts"
 end

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -11,5 +11,4 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 //= require jquery/dist/jquery
-//= require jquery_ujs
 //= require_tree .

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -10,6 +10,6 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
-//= require jquery
+//= require jquery/dist/jquery
 //= require jquery_ujs
 //= require_tree .


### PR DESCRIPTION
[TP10241](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/10241&appConfig=eyJhY2lkIjoiQzE1REE4NkE5M0U2Q0VFM0JCM0QyMzM2RUM0MzBGOUQifQ==)

This ticket updates the version of JQuery used in the Mortgage Calculator tool to 3.3.*

This is now ready to be merged. Note that for this tool we are keeping JQueryMigrate in place to deal with various warnings. This is subject to further future work as detailed in [TP10296](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/10296)