### PR TITLE
[DEV APPROVED] Bump dough-ruby to 3.6 for jquery upgrade

### DIFF
--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,8 +1,8 @@
 module MortgageCalculator
   module Version
     MAJOR = 3
-    MINOR = 5
-    PATCH = 2
+    MINOR = 6
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/mortgage_calculator.gemspec
+++ b/mortgage_calculator.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails"
   s.add_dependency "angularjs-rails", '~> 1.2.18'
   s.add_dependency "underscore-rails"
-  s.add_dependency "dough-ruby", "~> 5.35.0"
+  s.add_dependency "dough-ruby", "~> 5.36"
   s.add_dependency "mas-fonts"
 end


### PR DESCRIPTION
This pr is related to [TP 9827](https://moneyadviceservice.tpondemand.com/restui/board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=userstory/9827).

The work on this story overlapped with the jquery upgrades which necessitated locking dough-ruby to a pre upgrade version. Now that the upgrades are on production, we can change the dependency to be inline with the current version of dough-ruby.