### PR TITLE
[DEV APPROVED] 10350 Additional Dwelling Supplement for Scottish home buyers

### DIFF
--- a/app/helpers/mortgage_calculator/property_tax_calculator_helper.rb
+++ b/app/helpers/mortgage_calculator/property_tax_calculator_helper.rb
@@ -3,5 +3,9 @@ module MortgageCalculator
     def stamp_duty_calculator?
       resource.class.name == 'MortgageCalculator::StampDuty'
     end
+
+    def additional_property_rate
+      resource.class::SECOND_HOME_ADDITIONAL_TAX
+    end
   end
 end

--- a/app/models/mortgage_calculator/land_and_buildings_transaction_tax.rb
+++ b/app/models/mortgage_calculator/land_and_buildings_transaction_tax.rb
@@ -20,6 +20,8 @@ module MortgageCalculator
       { threshold: nil, rate: 12 }
     ].freeze
 
+    SECOND_HOME_ADDITIONAL_TAX = 4
+
     def first_time_ineligible?
       !first_time_buy?
     end

--- a/app/models/mortgage_calculator/land_transaction_tax.rb
+++ b/app/models/mortgage_calculator/land_transaction_tax.rb
@@ -13,6 +13,8 @@ module MortgageCalculator
       { threshold: nil, rate: 12 }
     ].freeze
 
+    SECOND_HOME_ADDITIONAL_TAX = 3
+
     protected
 
     def bands_to_use

--- a/app/models/mortgage_calculator/stamp_duty.rb
+++ b/app/models/mortgage_calculator/stamp_duty.rb
@@ -19,6 +19,7 @@ module MortgageCalculator
     ].freeze
 
     FIRST_TIME_BUYER_THRESHOLD = 500_000
+    SECOND_HOME_ADDITIONAL_TAX = 3
 
     def first_time_ineligible?
       first_time_buy? && price > FIRST_TIME_BUYER_THRESHOLD

--- a/app/models/mortgage_calculator/tax_calculator.rb
+++ b/app/models/mortgage_calculator/tax_calculator.rb
@@ -12,9 +12,9 @@ module MortgageCalculator
     validates :price, presence: true, numericality: true
 
     SECOND_HOME_THRESHOLD = 40_000
-    SECOND_HOME_ADDITIONAL_TAX = 3
     STANDARD_BUYER_TYPE = 'isNextHome'.freeze
     FIRST_TIME_BUYER_TYPE = 'isFTB'.freeze
+    SECOND_PROPERTY_BUYER = 'isSecondHome'.freeze
 
     def initialize(price: 0, buyer_type: STANDARD_BUYER_TYPE)
       self.price = price
@@ -53,7 +53,7 @@ module MortgageCalculator
     end
 
     def second_home?
-      buyer_type == 'isSecondHome'
+      buyer_type == SECOND_PROPERTY_BUYER
     end
 
     def self.banding_for(figures)
@@ -80,7 +80,7 @@ module MortgageCalculator
 
     def tax_for_band(band_start, band_end, rate)
       return 0 if price < band_start
-      rate += SECOND_HOME_ADDITIONAL_TAX if second_home_taxable?
+      rate += self.class::SECOND_HOME_ADDITIONAL_TAX if second_home_taxable?
       upper_limit = price_in_band?(band_end) ? price : band_end
       amount_to_tax = upper_limit - band_start.floor
       (amount_to_tax * rate / 100).floor

--- a/app/views/mortgage_calculator/property_tax_calculator/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/_form_step1.html.erb
@@ -21,7 +21,7 @@
         text: t("#{i18n_locale_namespace}.tooltip_show")
       } %>
       <%= popup_tip_content options: {
-        text: t("#{i18n_locale_namespace}.select.tooltip_html"),
+        text: t("#{i18n_locale_namespace}.select.tooltip_html", additional_property_rate: additional_property_rate),
         classname: 'details__helper',
         tooltip_hide: t("#{i18n_locale_namespace}.tooltip_hide")
       } %>

--- a/app/views/mortgage_calculator/property_tax_calculator/_next_home_buyer_explanation.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/_next_home_buyer_explanation.html.erb
@@ -1,5 +1,5 @@
 <p><%= I18n.t("#{i18n_locale_namespace}.how_calculated") %></p>
-<p><%= I18n.t("#{i18n_locale_namespace}.how_calculated_additional") %></p>
+<p><%= I18n.t("#{i18n_locale_namespace}.how_calculated_additional", additional_property_rate: additional_property_rate) %></p>
 
 <%= render 'bands_table', rates: rates %>
 

--- a/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
@@ -13,7 +13,13 @@
       <div class="stamp-duty__container">
         <h1 class="stamp-duty__heading"><%= I18n.t("#{i18n_locale_namespace}.heading") %></h1>
         <h2 class="intro stamp-duty__subheading"><%= I18n.t("#{i18n_locale_namespace}.title") %></h2>
-        <p><%= I18n.t("#{i18n_locale_namespace}.subtitle", amount: second_home_threshold) %></p>
+        <p>
+          <%= I18n.t(
+            "#{i18n_locale_namespace}.subtitle",
+            amount: second_home_threshold,
+            additional_property_rate: additional_property_rate
+          ) %>
+        </p>
         <%= render 'form_step1' %>
 
         <hr />

--- a/config/locales/land_and_buildings_transaction_tax.cy.yml
+++ b/config/locales/land_and_buildings_transaction_tax.cy.yml
@@ -10,7 +10,7 @@ cy:
     heading: "Cyfrifiannell Treth Trafodion Tir ac Adeiladau"
     subtitle: "Mae Treth Trafodiadau Tir ac Adeiladau (LBTT) wedi disodli Treth Stamp yn yr Alban. Os ydych chi'n prynu eiddo preswyl gwerth dros £145,000, bydd yn rhaid i chi dalu LBTT. Mae’r gyfrifiannell hon yn cyfrifo faint o Dreth Trafodiadau Tir ac Adeiladau fydd angen i chi dalu ar eich cartref newydd.
 
-      Mae hefyd yn cyfrifo faint fyddwch chi'n ei dalu ar unrhyw bryniant eiddo atodol dros £40,000, fel prynu i osod neu ail gartref, sy'n denu tâl ychwanegol o 3% fel Atodiad Annedd Atodol (ADS)."
+      Mae hefyd yn cyfrifo faint fyddwch chi'n ei dalu ar unrhyw bryniant eiddo atodol dros £40,000, fel prynu i osod neu ail gartref, sy'n denu tâl ychwanegol o %{additional_property_rate}% fel Atodiad Annedd Atodol (ADS)."
     heading_results: "Cyfrifiannell Treth Trafodion Tir ac Adeiladau - Eich canlyniadau"
     title: "Cyfrifwch y Dreth Trafodion Tir ac Adeiladau ar eich eiddo preswyl yn yr Alban"
     next: "Nesaf"
@@ -20,7 +20,7 @@ cy:
       option_isNextHome: "prynu fy nghartref nesaf"
       option_isFTB: prynu am y tro cyntaf
       option_isSecondHome: "prynu eiddo atodol neu eiddo prynu-i-osod"
-      tooltip_html: "Bydd unrhyw un sy’n prynu cartref ychwanegol gan gynnwys eiddo prynu i osod dros £40,000 mewn gwerth yn gorfod talu ffi ychwanegol o 3% ar ben pob band Treth Trafodiadau Tir ac Adeiladau."
+      tooltip_html: "Bydd unrhyw un sy’n prynu cartref ychwanegol gan gynnwys eiddo prynu i osod dros £40,000 mewn gwerth yn gorfod talu ffi ychwanegol o %{additional_property_rate}% ar ben pob band Treth Trafodiadau Tir ac Adeiladau."
     recalculate: Ailgyfrifo
     elsewhere:
       title: "Prynu yng Nghymru, Lloegr neu Ogledd Iwerddon?"
@@ -32,7 +32,7 @@ cy:
     how_calculated_ftb_4: "Golyga hynny bod cartrefi sydd â phrisiau prynu hyd at %{amount} wedi eu heithrio rhag LBTT fwy neu lai ar gyfer prynwyr tro cyntaf."
     how_calculated_ftb_5: "Er enghraifft:"
     how_calculated: "Telir Treth Trafodion Tir ac Adeiladau (LBTT) ar gyfraddau gwahanol, yn ddibynnol ar y band mae’r pris prynu ynddo. Er enghraifft, ni fyddai rhywun yn prynu eiddo am £280,000 yn talu treth ar werth yr eiddo hyd at £145,000, 2% o dreth ar werth yr eiddo rhwng £145,001 a £250,000 a 5% ar werth yr eiddo rhwng £250,001 a £280,000. Yn yr achos hwn, byddai cyfanswm yr atebolrwydd treth ar gyfer Treth Trafodion Tir ac Adeiladau (LBTT) yn £3,600 gan roi cyfradd dreth effeithiol o 1.29% (cyfartaledd cyfradd canrannol y dreth a dalwyd)."
-    how_calculated_additional: "Bydd unrhyw un sy’n prynu ail gartref, gan gynnwys eiddo prynu-i-osod, yn talu 3% ychwanegol ar ben y band cyfradd safonol. Yn yr enghraifft hon, byddai hynny'n cynrychioli £8,400 ychwanegol, sy'n golygu y byddai cyfanswm y dreth stamp yn £12,000 gan roi cyfradd treth effeithiol o 4.29%."
+    how_calculated_additional: "Bydd unrhyw un sy’n prynu ail gartref, gan gynnwys eiddo prynu-i-osod, yn talu %{additional_property_rate}% ychwanegol ar ben y band cyfradd safonol. Yn yr enghraifft hon, byddai hynny'n cynrychioli £11,200 ychwanegol, sy'n golygu y byddai cyfanswm y dreth stamp yn £14,800 gan roi cyfradd treth effeithiol o 5.29%."
     how_calculated_extra: "* Nid yw eiddo dan %{amount} yn destun yr Atodiad Annedd Atodol ar gyfer ail gartref"
     describe_price_field: "Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn."
     activemodel:

--- a/config/locales/land_and_buildings_transaction_tax.en.yml
+++ b/config/locales/land_and_buildings_transaction_tax.en.yml
@@ -10,7 +10,7 @@ en:
     heading: "Land and Buildings Transaction Tax (LBTT) calculator"
     subtitle: "Land and Buildings Transaction Tax (LBTT) has replaced Stamp Duty in Scotland. If you’re buying a residential property over £145,000, you’ll have to pay LBTT. This calculator works out how much Land and Buildings Transaction Tax you need to pay on your new home.
 
-      It also works out how much you’ll pay on any additional property purchase over £40,000, like a buy to let or second home, which attracts an extra 3% Additional Dwelling Supplement (ADS)."
+      It also works out how much you’ll pay on any additional property purchase over £40,000, like a buy to let or second home, which attracts an extra %{additional_property_rate}% Additional Dwelling Supplement (ADS)."
     heading_results: "Land and Buildings Transaction Tax (LBTT) calculator - Your Results"
     title: "Calculate the Land and Buildings Transaction Tax on your residential property in Scotland"
     next: Next
@@ -20,7 +20,7 @@ en:
       option_isNextHome: buying my next home
       option_isFTB: a first-time buyer
       option_isSecondHome: buying an additional or buy-to-let property
-      tooltip_html: "Anyone purchasing an additional home including buy to let properties over the value of £40,000 will have to pay an extra 3% surcharge on top of each Land and Buildings Transaction Tax band"
+      tooltip_html: "Anyone purchasing an additional home including buy to let properties over the value of £40,000 will have to pay an extra %{additional_property_rate}% surcharge on top of each Land and Buildings Transaction Tax band"
     recalculate: Recalculate
     elsewhere:
       title: "Buying in England, Northern Ireland or Wales?"
@@ -32,7 +32,7 @@ en:
     how_calculated_ftb_4: "It means that homes with purchase prices up to %{amount} are effectively free from LBTT for first-time buyers."
     how_calculated_ftb_5: "For example:"
     how_calculated: "Land and Buildings Transaction Tax (LBTT) is paid at different rates, depending on the band the purchase price falls into. For example, someone buying a property for £280,000 would pay no tax on the value of the property up to £145,000, 2% tax on the property value between £145,001 and £250,000 and 5% on the property value between £250,001 and £280,000. In this case, total liability for Land and Buildings Transaction Tax (LBTT) would be £3,600 giving an effective tax rate of 1.29% (average percentage rate of tax paid)."
-    how_calculated_additional: "Anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £8,400, meaning the total stamp duty would be £12,000 giving an effective tax rate of 4.29%."
+    how_calculated_additional: "Anyone buying a second home including a buy to let property will pay an extra %{additional_property_rate}% on top of the relevant standard rate band. In this example that would represent an extra £11,200, meaning the total stamp duty would be £14,800 giving an effective tax rate of 5.29%."
     how_calculated_extra: "* Properties under %{amount} are not subject to second home Additional Dwelling Supplement"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:

--- a/features/land_buildings_transaction_tax_calculator.feature
+++ b/features/land_buildings_transaction_tax_calculator.feature
@@ -71,11 +71,11 @@ Feature: Land and Buildings Transaction Tax Calculator
     When I enter a house price of <price>
     And I click next
     And I see the stamp duty I will have to pay is "£<duty>"
-    And I see the effective tax rate is "<effective tax>"
+    And I should see the tax rate being used is "<tax_rate>%"
 
     Examples:
-      | price   | duty   | effective tax |
-      | 35000   | 0      | 0.00%         |
-      | 50000   | 1,500  | 3.00%         |
-      | 260000  | 10,400 | 4.00%         |
-      | 750000  | 70,850 | 9.45%         |
+      | price   | duty   | tax_rate |
+      | 35000   | 0      | 0.00     |
+      | 50000   | 1,500  | 4.00     |
+      | 260000  | 13,000 | 5.00     |
+      | 750000  | 78,350 | 10.45    |

--- a/features/lbtt_how_calculated_panel.feature
+++ b/features/lbtt_how_calculated_panel.feature
@@ -24,11 +24,11 @@ Scenario: LBTT How is this calculated panel - Next home buyer journey
   And I click on the How is this Calculated information icon
   Then I should see the values on the information panel as:
   | Purchase price      | Rate of Land and Buildings Transaction Tax (LBTT) | Buy to Let/ Additional Dwelling Supplement (ADS)* |
-  | Up to £145,000      | 0%                 | 3%                                |
-  | £145,001 - £250,000 | 2%                 | 5%                                |
-  | £250,001 - £325,000 | 5%                 | 8%                                |
-  | £325,001 - £750,000 | 10%                | 13%                               |
-  | Over £750,000       | 12%                | 15%                               |
+  | Up to £145,000      | 0%                 | 4%                                |
+  | £145,001 - £250,000 | 2%                 | 6%                                |
+  | £250,001 - £325,000 | 5%                 | 9%                                |
+  | £325,001 - £750,000 | 10%                | 14%                               |
+  | Over £750,000       | 12%                | 16%                               |
 
 Scenario: LBTT How is this calculated panel - Additional home buyer journey
   Given I visit the land and buildings transaction tax page
@@ -37,8 +37,8 @@ Scenario: LBTT How is this calculated panel - Additional home buyer journey
   And I click on the How is this Calculated information icon
   Then I should see the values on the information panel as:
   | Purchase price      | Rate of Land and Buildings Transaction Tax (LBTT) | Buy to Let/ Additional Dwelling Supplement (ADS)* |
-  | Up to £145,000      | 0%                 | 3%                                |
-  | £145,001 - £250,000 | 2%                 | 5%                                |
-  | £250,001 - £325,000 | 5%                 | 8%                                |
-  | £325,001 - £750,000 | 10%                | 13%                               |
-  | Over £750,000       | 12%                | 15%                               |
+  | Up to £145,000      | 0%                 | 4%                                |
+  | £145,001 - £250,000 | 2%                 | 6%                                |
+  | £250,001 - £325,000 | 5%                 | 9%                                |
+  | £325,001 - £750,000 | 10%                | 14%                               |
+  | Over £750,000       | 12%                | 16%                               |

--- a/features/step_definitions/stamp_duty.rb
+++ b/features/step_definitions/stamp_duty.rb
@@ -79,6 +79,10 @@ Then(/^I see the stamp duty I will have to pay is "(.*?)"$/) do |content|
   expect(@stamp_duty).to have_content(content)
 end
 
+Then(/^I should see the tax rate being used is "(.*?)"$/) do |tax_rate|
+  expect(@stamp_duty.tax_due.first).to have_content(tax_rate)
+end
+
 And(/^I see that the stamp duty cost falls into a band of "(.*?)"$/) do |content|
   expect(@stamp_duty).to have_content(content)
 end

--- a/features/support/ui/pages/land_and_buildings_transaction_tax.rb
+++ b/features/support/ui/pages/land_and_buildings_transaction_tax.rb
@@ -11,6 +11,7 @@ module UI
       element :property_price_step_two, "form.step_two input[name='land_and_buildings_transaction_tax[price]']"
       element :next, "form.step_one input[type=submit]"
       element :how_is_this_calculated_link, ".stamp-duty__how-calculated-toggle"
+      elements :tax_due, ".stamp-duty__results-tax-rate"
       elements :lbtt_ftb_table_headings, ".mortgagecalc__table.stamp-duty__table thead tr"
       elements :lbtt_how_calculated_examples, ".mortgagecalc__table.stamp-duty__table tbody tr"
     end

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,8 +1,8 @@
 module MortgageCalculator
   module Version
     MAJOR = 3
-    MINOR = 6
-    PATCH = 2
+    MINOR = 7
+    PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/spec/helpers/property_tax_helper_spec.rb
+++ b/spec/helpers/property_tax_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module MortgageCalculator
+  describe PropertyTaxCalculatorHelper, type: :helper do
+    describe '#additional_property_rate' do
+      context 'when Stamp Duty Calculator' do
+        let(:resource) { MortgageCalculator::StampDuty.new }
+
+        it 'returns the Stamp Duty\'s Second Home Tax constant' do
+          expect(additional_property_rate).to eq(3)
+        end
+      end
+
+      context 'when Land and Buildings Transaction Tax(LBTT) Calculator' do
+        let(:resource) { MortgageCalculator::LandAndBuildingsTransactionTax.new }
+
+        it 'returns the LBTT\'s Second Home Tax constant' do
+          expect(additional_property_rate).to eq(4)
+        end
+      end
+
+      context 'when Land Transaction Tax(LTT) Calculator' do
+        let(:resource) { MortgageCalculator::LandTransactionTax.new }
+
+        it 'returns the LTT\'s Second Home Tax constant' do
+          expect(additional_property_rate).to eq(3)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/land_and_buildings_transaction_tax_spec.rb
+++ b/spec/models/land_and_buildings_transaction_tax_spec.rb
@@ -125,9 +125,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(1200) }
-        its(:percentage_tax) { is_expected.to eq(3) }
-        its(:total_due) { is_expected.to eq(41_200) }
+        its(:tax_due) { is_expected.to eq(1600) }
+        its(:percentage_tax) { is_expected.to eq(4.0) }
+        its(:total_due) { is_expected.to eq(41_600) }
       end
     end
 
@@ -153,9 +153,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(4350) }
-        its(:percentage_tax) { is_expected.to eq(3) }
-        its(:total_due) { is_expected.to eq(149_350) }
+        its(:tax_due) { is_expected.to eq(5800) }
+        its(:percentage_tax) { is_expected.to eq(4) }
+        its(:total_due) { is_expected.to eq(150_800) }
       end
     end
 
@@ -181,9 +181,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(6350) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(3.43) }
-        its(:total_due) { is_expected.to eq(191_350) }
+        its(:tax_due) { is_expected.to eq(8200) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.43) }
+        its(:total_due) { is_expected.to eq(193_200) }
       end
     end
 
@@ -209,9 +209,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(11_600) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.22) }
-        its(:total_due) { is_expected.to eq(286_600) }
+        its(:tax_due) { is_expected.to eq(14_350) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(5.22) }
+        its(:total_due) { is_expected.to eq(289_350) }
       end
     end
 
@@ -237,9 +237,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(13_600) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.53) }
-        its(:total_due) { is_expected.to eq(313_600) }
+        its(:tax_due) { is_expected.to eq(16_600) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(5.53) }
+        its(:total_due) { is_expected.to eq(316_600) }
       end
     end
 
@@ -265,9 +265,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(37_050) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(7.56) }
-        its(:total_due) { is_expected.to eq(527_050) }
+        its(:tax_due) { is_expected.to eq(41_950) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(8.56) }
+        its(:total_due) { is_expected.to eq(531_950) }
       end
     end
 
@@ -293,9 +293,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(39_650) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(7.77) }
-        its(:total_due) { is_expected.to eq(549_650) }
+        its(:tax_due) { is_expected.to eq(44_750) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(8.77) }
+        its(:total_due) { is_expected.to eq(554_750) }
       end
     end
 
@@ -321,9 +321,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(98_975) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(10.56) }
-        its(:total_due) { is_expected.to eq(1_036_475) }
+        its(:tax_due) { is_expected.to eq(108_350) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(11.56) }
+        its(:total_due) { is_expected.to eq(1_045_850) }
       end
     end
 
@@ -349,9 +349,9 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(273_350) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(13.02) }
-        its(:total_due) { is_expected.to eq(2_373_350) }
+        its(:tax_due) { is_expected.to eq(294_350) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(14.02) }
+        its(:total_due) { is_expected.to eq(2_394_350) }
       end
     end
   end


### PR DESCRIPTION
[TP 10350](https://moneyadviceservice.tpondemand.com/restui/board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&boardPopup=userstory/10350/silent)

The Additional Dwelling Supplement for Scottish home buyers has increased from 3% to 4%. This pr makes the necessary changes to ensure the calculations are correct for Additional Property buyers in Scotland and the correct information is displayed.