### PR TITLE
[DEV APPROVED] 10354 Update information text on the results page

### DIFF
--- a/config/locales/land_and_buildings_transaction_tax.cy.yml
+++ b/config/locales/land_and_buildings_transaction_tax.cy.yml
@@ -61,9 +61,9 @@ cy:
     next_steps:
       learn_more:
         title: "A wyddech chi?"
-        tip_1: "Rhaid i chi dalu Treth Trafodiadau Tir ac Adeiladau (LBTT) cyn pen 30 diwrnod ar ôl prynu eiddo. Os ydych yn defnyddio cyfreithiwr i gwblhau’r trawsgludo, bydd fel arfer yn trefnu’r taliad ar eich rhan."
+        tip_1: "Mae’n bosibl y bydd angen i chi dalu Treth Trafodiadau Tir ac Adeiladau (LBTT) ar drafodiadau tir ac eiddo preswyl ac amhreswyl. Cyfrifoldeb y trethdalwr yw llenwi a chyflwyno ffurflen LBTT gywir, yn ôl y gofyn, a thalu unrhyw dreth sy’n ddyledus. Mae gwybodaeth bellach i’w gweld ar:"
         link_1:
-          title: "Treth Trafodiadau Tir ac Adeiladau (LBTT) - popeth sydd angen i chi ei wybod"
+          title: "Treth Trafodiadau Tir ac Adeiladau (LBTT) - Popeth y mae angen i chi wybod"
           url: "/cy/articles/treth-trafodiadau-tir-ac-adeiladau-popeth-y-mae-angen-i-chi-ei-wybod/"
       find_out_more:
         title: "Darganfyddwch fwy"

--- a/config/locales/land_and_buildings_transaction_tax.en.yml
+++ b/config/locales/land_and_buildings_transaction_tax.en.yml
@@ -61,7 +61,7 @@ en:
     next_steps:
       learn_more:
         title: "Did you know?"
-        tip_1: "You have to pay Land and Buildings Transaction Tax (LBTT) within 30 days of buying a property. If you're using a solicitor to carry out the conveyancing, they will normally organise the payment for you."
+        tip_1: "You may have to pay Land and Buildings Transaction Tax (LBTT) on residential and non-residential land and property transactions. It is the responsibility of the taxpayer to complete and submit an accurate LBTT return, where required, and pay any tax due. Further information can be found on:"
         link_1:
           title: "Land and Buildings Transaction Tax (LBTT) - Everything you need to know"
           url: "/en/articles/land-and-buildings-transaction-tax-everything-you-need-to-know"

--- a/features/land_buildings_transaction_tax_calculator.feature
+++ b/features/land_buildings_transaction_tax_calculator.feature
@@ -10,6 +10,7 @@ Feature: Land and Buildings Transaction Tax Calculator
     When I enter a house price of <price>
     And I am a next home buyer
     And I click next
+    Then I see the call out box with everything I need to know
     And I see the stamp duty I will have to pay is "£<duty>"
     And I see the effective tax rate is "<effective tax>"
 
@@ -31,7 +32,8 @@ Feature: Land and Buildings Transaction Tax Calculator
     When I enter a house price of <price>
     And I am a next home buyer
     And I click next
-    Then I see the stamp duty I will have to pay is "£<duty>"
+    Then I see the call out box with everything I need to know
+    And I see the stamp duty I will have to pay is "£<duty>"
 
   Examples:
     | price   | duty   | effective tax |
@@ -70,6 +72,7 @@ Feature: Land and Buildings Transaction Tax Calculator
     Given I am an additional or buy-to-let property buyer
     When I enter a house price of <price>
     And I click next
+    Then I see the call out box with everything I need to know
     And I see the stamp duty I will have to pay is "£<duty>"
     And I should see the tax rate being used is "<tax_rate>%"
 

--- a/features/land_buildings_transaction_tax_first_time_buyer.feature
+++ b/features/land_buildings_transaction_tax_first_time_buyer.feature
@@ -11,7 +11,8 @@ Scenario Outline: land and buildings transaction tax for first home
   And I am a first time buyer
   And I click next
   Then I see the title for the "Land and Buildings Transaction Tax (LBTT)" results page
-  Then I see the stamp duty I will have to pay is "£<duty>"
+  And I see the call out box with everything I need to know
+  And I see the stamp duty I will have to pay is "£<duty>"
 
 Examples:
   |  price    |  duty    |
@@ -31,8 +32,8 @@ Scenario Outline: land and buildings transaction tax for first home
   When I enter a house price of <price>
   And I am a first time buyer
   And I click next
-  
-  Then I see the stamp duty I will have to pay is "£<duty>"
+  Then I see the call out box with everything I need to know
+  And I see the stamp duty I will have to pay is "£<duty>"
 
 Examples:
   | price      | duty     |

--- a/features/step_definitions/land_and_buildings_transaction_tax.rb
+++ b/features/step_definitions/land_and_buildings_transaction_tax.rb
@@ -42,3 +42,9 @@ Then('I should see the values on the information panel as:') do |table|
     ).to have_content(rows[index].join(' '))
   end
 end
+
+Then('I see the call out box with everything I need to know') do
+  content = 'You may have to pay Land and Buildings Transaction Tax (LBTT) on residential and non-residential land and property transactions. It is the responsibility of the taxpayer to complete and submit an accurate LBTT return, where required, and pay any tax due. Further information can be found on:'
+  expect(@stamp_duty).to have_call_out_box
+  expect(@stamp_duty.call_out_tip.text).to be_include(content)
+end

--- a/features/support/ui/pages/land_and_buildings_transaction_tax.rb
+++ b/features/support/ui/pages/land_and_buildings_transaction_tax.rb
@@ -11,6 +11,8 @@ module UI
       element :property_price_step_two, "form.step_two input[name='land_and_buildings_transaction_tax[price]']"
       element :next, "form.step_one input[type=submit]"
       element :how_is_this_calculated_link, ".stamp-duty__how-calculated-toggle"
+      element :call_out_box, ".callout__heading"
+      element :call_out_tip, ".stamp-duty__info-tip"
       elements :tax_due, ".stamp-duty__results-tax-rate"
       elements :lbtt_ftb_table_headings, ".mortgagecalc__table.stamp-duty__table thead tr"
       elements :lbtt_how_calculated_examples, ".mortgagecalc__table.stamp-duty__table tbody tr"

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 3
-    MINOR = 7
+    MINOR = 8
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
[TP 10354](https://moneyadviceservice.tpondemand.com/restui/board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&boardPopup=userstory/10354/silent)

Specifically for the Land and Buildings Transaction Tax calculator,
the text in the call out box needs to be amended as currently it gives
incorrect information.

BEFORE
<img width="562" alt="Screen Shot 2019-04-03 at 16 41 27" src="https://user-images.githubusercontent.com/3481059/55492687-8bc66f00-562f-11e9-9b1d-db55738b5ea5.png">

AFTER
<img width="557" alt="Screen Shot 2019-04-03 at 16 42 04" src="https://user-images.githubusercontent.com/3481059/55492671-81a47080-562f-11e9-9511-41e36e1cd2ca.png">

