### PR TITLE
[DEV APPROVED] 10480 tooltip position

### DIFF
--- a/app/views/mortgage_calculator/affordabilities/_form_step1.html.erb
+++ b/app/views/mortgage_calculator/affordabilities/_form_step1.html.erb
@@ -51,7 +51,7 @@
           <%= person.form_row :monthly_net_income do %>
             <%= person.errors_for :monthly_net_income %>
             <%= person.label :monthly_net_income, "id" => "label_monthly_net_income_0" do %>
-              <%= t('affordability.activemodel.attributes.mortgage_calculator/person.monthly_net_income')%> * 
+              <%= t('affordability.activemodel.attributes.mortgage_calculator/person.monthly_net_income')%> *
               <span class="affcalc__row affcalc__sub-label"><%= t("affordability.activemodel.attributes.mortgage_calculator/person.monthly_net_sub")%></span>
               <span class="visually-hidden"><%= t('affordability.per_month') %>, <%= t('affordability.required') %></span>
             <% end %>
@@ -77,11 +77,13 @@
         </div>
       </div>
 
-      <div class="affcalc__row" data-dough-component="PopupTip">
+      <div class="affcalc__row">
         <div class="affcalc__col--field">
           <%= person.form_row :extra_income do %>
             <%= person.errors_for :extra_income %>
-            <%= person.label :extra_income, "id" => "label_extra_income0" do %>
+            <%= person.label :extra_income,
+              "id" => "label_extra_income0",
+              "data-dough-component" => "PopupTip" do %>
               <%= t('affordability.activemodel.attributes.mortgage_calculator/person.extra_income') %>
               <%= render 'mortgage_calculator/affordabilities/tooltips/trigger' %>
               <div data-dough-popup-container class="popup-tip__container details__helper">

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 3
     MINOR = 8
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
[TP10480](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiNTM0ODcyOThDQjBDMTMyMDgyMTBENEZEM0QwM0ZBQzkifQ==&boardPopup=bug/10480/silent)

The PopupTip Dough component is displaying wrongly on the Mortgage Affordability Calculator tool. Instead of the expected offset from the trigger element the tooltip is being rendered at a considerable distance below this. 

The reason is that the Dough component is being applied on a distant DOM element from the trigger rather than on the immediate parent. This PR moves the location of the element that loads the component to the correct place in the DOM. 

![image](https://user-images.githubusercontent.com/6080548/59360439-fd095900-8d27-11e9-9f14-31466dc6abca.png)
