### PR TITLE
10759 stamp duty copy changes

### DIFF
--- a/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
@@ -14,11 +14,15 @@
         <h1 class="stamp-duty__heading"><%= I18n.t("#{i18n_locale_namespace}.heading") %></h1>
         <h2 class="intro stamp-duty__subheading"><%= I18n.t("#{i18n_locale_namespace}.title") %></h2>
         <p>
-          <%= I18n.t(
-            "#{i18n_locale_namespace}.subtitle",
-            amount: second_home_threshold,
-            additional_property_rate: additional_property_rate
-          ) %>
+          <%= I18n.t("#{i18n_locale_namespace}.subtitle") %>
+          <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland" target="_blank">
+            <%= I18n.t("#{i18n_locale_namespace}.subtitle_href_scotland") %>
+          </a>
+          <%= I18n.t("#{i18n_locale_namespace}.subtitle_href_separator") %>
+          <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-transaction-tax-calculator-wales" target="_blank">
+            <%= I18n.t("#{i18n_locale_namespace}.subtitle_href_wales") %>
+          </a>
+          <%= I18n.t("#{i18n_locale_namespace}.subtitle_2") %>
         </p>
         <%= render 'form_step1' %>
 

--- a/app/views/mortgage_calculator/shared/_links_to_other_tools.html.erb
+++ b/app/views/mortgage_calculator/shared/_links_to_other_tools.html.erb
@@ -3,7 +3,6 @@
     <a class="elsewhere__item promo__link" href="<%= I18n.t("stamp_duty.elsewhere.#{country}.link") %>">
       <div class="elsewhere__item-content">
         <h3 class="promo__heading"><%= I18n.t("stamp_duty.elsewhere.#{country}.title") %></h3>
-        <p class="promo__content"><%= I18n.t("stamp_duty.elsewhere.#{country}.body") %></p>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--arrow-right elsewhere__arrow" focusable="false">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--arrow-right"></use>

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -11,7 +11,7 @@ cy:
     heading: "Cyfrifiannell treth stamp"
     heading_results: "Cyfrifiannell treth stamp - Eich canlyniadau"
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl prynu yng Lloegr neu Ogledd Iwerddon"
-    subtitle: Mae Treth Dir y Dreth Stamp (SDLT) yn dreth ar eiddo a brynir yn Lloegr a Gogledd Iwerddon. Bydd angen i chi ei thalu pan fyddwch yn prynu eiddo preswyl sy'n costio mwy na £125,000. Defnyddiwch y gyfrifiannell hon i gyfrifo faint o Dreth Stamp fydd angen i chi dalu ar eich cartref newydd. Gallwch hefyd ei ddefnyddio i gyfrifo faint fyddwch chi'n ei dalu ar eiddo atodol sy'n costio mwy na %{amount}, fel prynu i osod neu ail gartref, sy'n denu tâl ychwanegol o 3%.
+    subtitle: Os prynwch eiddo dros drothwy presennol y SDLT o £125,000, yna mae'n rhaid i chi dalu Treth Tir y Doll Stamp (SDLT). Os yw'ch eiddo neu'ch tir yng <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland" target="_blank">Nghymru</a> neu'r <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-transaction-tax-calculator-wales" target="_blank">Alban</a> rydych yn talu treth wahanol. Ceir rheolau gwahanol os ydych chi neu'r unigolyn sy'n prynu ar y cyd â chi yn brynwyr tro cyntaf, sy'n prynu eich cartref cyntaf ac os yw'r pris prynu yn llai na £500,000. Bydd unrhyw un sy'n prynu eiddo preswyl ychwanegol sy'n werth £40,000 neu ragor yn gorfod prynu treth stamp ychwanegol hyd yn oed os yw'r eiddo sy'n berchen i chi eisoes wedi ei leoli dramor. Rhaid i chi anfon ffurflen SDLT i HMRC a thalu'r dreth cyn pen 14 diwrnod.
     second_subtitle: "Mae Treth Trafodion Tir ac Adeiladau (LBTT) wedi disodli Treth Stamp yn yr Alban. Bydd trethi LBTT yn destun ffi ychwanegol o 3% hefyd ar gyfer ail gartrefi."
     href_second_subtitle: "Cyfrifwch yr LBTT sy'n daladwy"
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
@@ -21,22 +21,20 @@ cy:
       option_prompt: dewiswch opsiwn
       option_isNextHome: prynu fy nghartref nesaf
       option_isFTB: prynu am y tro cyntaf
-      option_isSecondHome: prynu eiddo atodol neu eiddo prynu-i-osod
-      tooltip_html: Codir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar os ydych yn prynu am y tro cyntaf, yn prynu eich cartref nesaf neu'n prynu eiddo atodol neu eiddo prynu-i-osod. <br /><br />Yn gyffredinol, rydych yn cael eich dosbarthu yn brynwr tro cyntaf os ydych chi'n prynu eich unig neu brif gartref ac nad ydych erioed wedi bod yn berchen ar eiddo yn y Deyrnas Unedig na thramor. <a href="https://www.moneyadviceservice.org.uk/cy/articles/awgrymiadau-ar-arian-i-brynwyr-tro-cyntaf" target="_blank">Darllenwch fwy yn ein canllaw i brynwyr tro cyntaf</a>.
+      option_isSecondHome: prynu eiddo ychwanegol neu ail gartref
+      tooltip_html: Os prynwch eiddo dros bris penodol yn Lloegr a Gogledd Iwerddon, yna rhaid i chi dalu Treth Tir y Doll Stamp (SDLT). Ceir rheolau gwahanol os ydych yn prynu'ch cartref cyntaf neu eiddo preswyl ychwanegol. <br /><br />Ceir rheolau gwahanol os ydych yn prynu'ch cartref cyntaf. Cewch ostyngiad sy'n golygu y byddwch yn talu llai o dreth neu ddim treth o gwbl. Mae prynwr tro cyntaf yn unigolyn sydd erioed wedi sicrhau buddsoddiad mewn eiddo un ai yn y DU neu unrhyw le arall yn y byd a'i fwriad yw byw yn yr eiddo fel ei brif breswylfa. <a href="https://www.moneyadviceservice.org.uk/cy/articles/awgrymiadau-ar-arian-i-brynwyr-tro-cyntaf" target="_blank">Darllenwch fwy yn ein canllaw i brynwyr tro cyntaf</a>. <br /><br />Yn gyffredinol rhaid i chi dalu'r cyfraddau SDLT uwch pan brynwch eiddo preswyl neu ran o un os nad hwnnw fydd yr unig eiddo preswyl yr ydych yn berchen arno (neu'n berchen ar y cyd) yn unrhyw le yn y byd, os nad ydych wedi gwerthu neu roi eich prif gartref blaenorol i rywun ac nid oes gan neb les arno sydd â mwy na 21 mlynedd yn weddill. Mae'r rheolau hyn yn berthnasol os ydych yn briod neu'n prynu ar y cyd a'r unigolyn hwnnw neu honno.
     elsewhere:
       title: Prynu yn yr Alban neu Cymru?
-      body: Os ydych chi'n prynu yn unrhyw un o'r gwledydd hyn, yna defnyddiwch y gyfrifiannell briodol i gyfrifo faint fyddwch chi'n ei dalu
+      body: Yng Nghymru a'r Alban, yr hyn sy'n cyfateb i Dreth Dir y Dreth Stamp (SDLT) a delir yn Lloegr a Gogledd Iwerddon, yw'r Dreth Trafodion Tir yng Nghymru (LTT) a'r Dreth Trafodion Tir ac Adeiladau (LBTT) yn yr Alban.
       england_ni:
         title: "Cyfrifwch Dreth Stamp yng Nghymru, Lloegr neu Ogledd Iwerddon"
         body: "Rhaid talu Treth Stamp ar eiddo yn Lloegr a Gogledd Iwerddon o hyd"
         link: "/cy/tools/prynu-ty/cyfrifiannell-treth-stamp"
       wales:
         title: Cyfrifwch Dreth Trafodiadau Tir ar gyfer Cymru
-        body: Mae Treth Trafodiadau Tir ac (LTT) wedi disodli Treth Stamp yng Nghymru.
         link: /cy/tools/prynu-ty/cyfrifiannell-treth-trafodiadau-tir-cymru
       scotland:
         title: Cyfrifwch Dreth Trafodiadau Tir ac Adeiladau ar gyfer yr Alban
-        body: Mae Treth Trafodiadau Tir ac Adeiladau (LBTT) wedi disodli Treth Stamp yn yr Alban.
         link: /cy/tools/prynu-ty/cyfrifiannell-treth-trafodion-tir-ac-adeiladau-alban
     recalculate: Ailgyfrifo
     how_calculated_toggle: "Sut y cyfrifir hyn?"
@@ -54,9 +52,9 @@ cy:
       - "5% o dreth ar werth yr eiddo rhwng £250,001 a £550,000."
     how_calculated_ftb_6: "Yn yr achos hwn, byddai cyfanswm y Dreth Stamp yn £17,500, gan roi cyfradd treth effeithiol o 3.2%."
     how_calculated_ftb_7: "Mae'r cyfraddau hyn yn gymwys i Gymru, Lloegr a Gogledd Iwerddon ar hyn o bryd."
-    how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n prynu eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp gan roi cyfradd dreth effeithiol o 1%."
-    how_calculated_additional: "Bydd unrhyw un sy'n prynu ail gartref, gan gynnwys eiddo prynu i osod, yn talu 3% ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny'n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750, gan roi cyfradd dreth effeithiol o 4%."
-    how_calculated_extra: "* Nid yw eiddo dan %{amount} yn destun SDLT ail gartref"
+    how_calculated: "Telir Treth Stamp ar wahanol gyfraddau yn ddibynnol ar y pris prynu. Er enghraifft, byddai rhywun sy’n gorfod talu Treth Stamp ar eiddo am £245,000 yn talu dim treth o gwbl ar werth yr eiddo hyd at £125,000 a 2% o dreth ar werth yr eiddo rhwng £125,001 a £245,000. Yn yr achos hwn, £2,400 fyddai’r swm gofynnol o Dreth Stamp gan roi cyfradd dreth effeithiol o 1%."
+    how_calculated_additional: "Bydd y rhai sy'n destun cyfraddau ychwanegol o dreth stamp yn talu 3% yn ychwanegol ar ben y band cyfradd safonol perthnasol. Yn yr enghraifft hon byddai hynny’n golygu £7,350 yn ychwanegol, ac felly byddai cyfanswm y dreth stamp yn £9,750, gan roi cyfradd dreth wirioneddol o 4%."
+    how_calculated_extra: "* Nid yw eiddo dan %{amount} yn destun y cyfraddau SDLT ychwanegol"
     describe_price_field: Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn.
     activemodel:
       attributes:
@@ -76,7 +74,7 @@ cy:
     table:
       property_price_header: "Pris Prynu"
       rate_header: "Cyfradd treth stamp"
-      extra_rate_header: "Cyfradd Prynu i Werthu neu Gartref Ychwanegol *"
+      extra_rate_header: "Cyfradd Eiddo Ychwanegol*"
       standard_rates_apply: "Codir cyfraddau safonol (gweler isod)"
       over_a_million: Dros £%{number} miliwn
     next_steps:

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -11,7 +11,11 @@ cy:
     heading: "Cyfrifiannell treth stamp"
     heading_results: "Cyfrifiannell treth stamp - Eich canlyniadau"
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl prynu yng Lloegr neu Ogledd Iwerddon"
-    subtitle: Os prynwch eiddo dros drothwy presennol y SDLT o £125,000, yna mae'n rhaid i chi dalu Treth Tir y Doll Stamp (SDLT). Os yw'ch eiddo neu'ch tir yng <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland" target="_blank">Nghymru</a> neu'r <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-transaction-tax-calculator-wales" target="_blank">Alban</a> rydych yn talu treth wahanol. Ceir rheolau gwahanol os ydych chi neu'r unigolyn sy'n prynu ar y cyd â chi yn brynwyr tro cyntaf, sy'n prynu eich cartref cyntaf ac os yw'r pris prynu yn llai na £500,000. Bydd unrhyw un sy'n prynu eiddo preswyl ychwanegol sy'n werth £40,000 neu ragor yn gorfod prynu treth stamp ychwanegol hyd yn oed os yw'r eiddo sy'n berchen i chi eisoes wedi ei leoli dramor. Rhaid i chi anfon ffurflen SDLT i HMRC a thalu'r dreth cyn pen 14 diwrnod.
+    subtitle: Os prynwch eiddo dros drothwy presennol y SDLT o £125,000, yna mae'n rhaid i chi dalu Treth Tir y Doll Stamp (SDLT). Os yw'ch eiddo neu'ch tir yng 
+    subtitle_2: rydych yn talu treth wahanol. Ceir rheolau gwahanol os ydych chi neu'r unigolyn sy'n prynu ar y cyd â chi yn brynwyr tro cyntaf, sy'n prynu eich cartref cyntaf ac os yw'r pris prynu yn llai na £500,000. Bydd unrhyw un sy'n prynu eiddo preswyl ychwanegol sy'n werth £40,000 neu ragor yn gorfod prynu treth stamp ychwanegol hyd yn oed os yw'r eiddo sy'n berchen i chi eisoes wedi ei leoli dramor. Rhaid i chi anfon ffurflen SDLT i HMRC a thalu'r dreth cyn pen 14 diwrnod.
+    subtitle_href_scotland: Nghymru
+    subtitle_href_wales: Alban 
+    subtitle_href_separator: neu'r 
     second_subtitle: "Mae Treth Trafodion Tir ac Adeiladau (LBTT) wedi disodli Treth Stamp yn yr Alban. Bydd trethi LBTT yn destun ffi ychwanegol o 3% hefyd ar gyfer ail gartrefi."
     href_second_subtitle: "Cyfrifwch yr LBTT sy'n daladwy"
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -11,7 +11,7 @@ en:
     heading: "Stamp Duty calculator"
     heading_results: "Stamp Duty Calculator - Your Results"
     title: Calculate the Stamp Duty on your residential property purchase in England or Northern Ireland
-    subtitle: Stamp Duty Land Tax (SDLT) is a tax on properties bought in England and Northern Ireland. You’ll need to pay it when you buy a residential property that costs more than £125,000. Use this calculator to work out how much Stamp Duty you’ll need to pay on your new home. You can also use it to work out how much you’ll pay on an additional property that costs more than %{amount}, like a buy to let or second home, which attracts an extra 3% charge.
+    subtitle: SYou must pay Stamp Duty Land Tax (SDLT) if you buy a property over the current SDLT threshold of £125,000. You pay a different tax if your property or land is in <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland" target="_blank">Scotland</a> or <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-transaction-tax-calculator-wales" target="_blank">Wales</a>. There are different rules if you or the person you’re buying with are first time buyers purchasing their first home and the purchase price is less than £500,000. Anyone buying an additional residential property worth £40,000 or more will have to pay additional stamp duty even if the property you already own is abroad. You must send an SDLT return to HMRC and pay the tax within 14 days.
     href_second_subtitle: "Calculate the LBTT payable."
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
     next: Next
@@ -20,22 +20,20 @@ en:
       option_prompt: please select an option
       option_isNextHome: buying my next home
       option_isFTB: a first-time buyer
-      option_isSecondHome: buying an additional or buy-to-let property
-      tooltip_html: Stamp Duty is applied at different rates depending on whether you are a first-time buyer, buying your next home, or buying an additional or buy-to-let property. <br /><br />You are generally classified as a first-time buyer if you’re buying your only or main residence and you have never owned a property in the UK or abroad. <a href="https://www.moneyadviceservice.org.uk/en/articles/first-time-buyer-money-tips" target="_blank">Read more in our First-time buyer guide</a>.
+      option_isSecondHome: buying an additional property or second home
+      tooltip_html: You must pay Stamp Duty Land Tax (SDLT) if you buy a property or land over a certain price in England and Northern Ireland. There are different rules if you’re buying your first home or an additional residential property. <br /><br />There are different rules if you’re buying your first home. You get a discount (relief) that means you pay less or no tax. A first-time buyer is an individual who has never acquired a major interest in a property either in the UK or anywhere else in the world and intends to live in the property as their only or main residence. <a href="https://www.moneyadviceservice.org.uk/en/articles/first-time-buyer-money-tips" target="_blank">Read more in our First-time buyer guide</a>. <br /><br />You must generally pay the higher SDLT rates when you buy a residential property or a part of one if it will not be the only residential property that you own (or part own) anywhere in the world, you have not sold or given away your previous main home and no one else has a lease on it which has more than 21 years left to run. These rules apply if you’re married to or buying with someone.
     elsewhere:
       title: Buying in Scotland or Wales?
-      body: If you are buying in either of these countries then use the appropriate calculator to work out how much you will pay
+      body: The Scottish and Welsh equivalents of the Stamp Duty Land Tax (SDLT) paid in England and Northern Ireland is the Land and Buildings Transaction Tax (LBTT) in Scotland the Land Transaction Tax (LTT) in Wales.
       england_ni:
         title: Calculate Stamp Duty in England or Northern Ireland
         body: Properties in England and Northen Ireland are still subject to Stamp Duty.
         link: "/en/tools/house-buying/stamp-duty-calculator"
       wales:
         title: Calculate Land Transaction Tax for Wales
-        body: Land Transaction Tax (LTT) has replaced Stamp Duty in Wales.
         link: "/en/tools/house-buying/land-transaction-tax-calculator-wales"
       scotland:
         title: Calculate Land and Buildings Transaction Tax for Scotland
-        body: Land and Buildings Transaction Tax (LBTT) has replaced Stamp Duty in Scotland.
         link: "/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland"
     recalculate: Recalculate
     how_calculated_toggle: "How is this calculated?"
@@ -53,9 +51,9 @@ en:
       - "5% tax on the property value between £250,001 and £550,000."
     how_calculated_ftb_6: "In this case, the total amount of Stamp Duty would be £17,500, giving an effective tax rate of 3.2%."
     how_calculated_ftb_7: "These rates currently apply to England, Wales and Northern Ireland"
-    how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400 giving an effective tax rate of 1%."
-    how_calculated_additional: "Anyone buying a second home including a buy to let property will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
-    how_calculated_extra: "* Properties under %{amount} are not subject to second home SDLT"
+    how_calculated: "Stamp Duty is paid at different rates, depending on the purchase price. For example, someone subject to Stamp Duty buying a property for £245,000 would pay no tax on the value of the property up to £125,000 and 2% tax on the property value between £125,001 and £245,000. In this case, total liability for Stamp Duty would be £2,400 giving an effective tax rate of 1%."
+    how_calculated_additional: "Those subject to the additional rates of stamp duty rates will pay an extra 3% on top of the relevant standard rate band. In this example that would represent an extra £7,350, meaning the total stamp duty would be £9,750 giving an effective tax rate of 4%."
+    how_calculated_extra: "* Properties under %{amount} are not subject to the additional SDLT rates"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:
       attributes:
@@ -75,7 +73,7 @@ en:
     table:
       property_price_header: "Purchase price of property"
       rate_header: "Rate of Stamp Duty"
-      extra_rate_header: "Buy to Let/ Additional Home Rate*"
+      extra_rate_header: "Additional Property Rate*"
       standard_rates_apply: "Standard rates apply (see below)"
       over_million: Over £%{number} million
     next_steps:

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -11,7 +11,11 @@ en:
     heading: "Stamp Duty calculator"
     heading_results: "Stamp Duty Calculator - Your Results"
     title: Calculate the Stamp Duty on your residential property purchase in England or Northern Ireland
-    subtitle: SYou must pay Stamp Duty Land Tax (SDLT) if you buy a property over the current SDLT threshold of £125,000. You pay a different tax if your property or land is in <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland" target="_blank">Scotland</a> or <a href="https://www.moneyadviceservice.org.uk/en/tools/house-buying/land-transaction-tax-calculator-wales" target="_blank">Wales</a>. There are different rules if you or the person you’re buying with are first time buyers purchasing their first home and the purchase price is less than £500,000. Anyone buying an additional residential property worth £40,000 or more will have to pay additional stamp duty even if the property you already own is abroad. You must send an SDLT return to HMRC and pay the tax within 14 days.
+    subtitle: "You must pay Stamp Duty Land Tax (SDLT) if you buy a property over the current SDLT threshold of £125,000. You pay a different tax if your property or land is in " 
+    subtitle_2: "There are different rules if you or the person you’re buying with are first time buyers purchasing their first home and the purchase price is less than £500,000. Anyone buying an additional residential property worth £40,000 or more will have to pay additional stamp duty even if the property you already own is abroad. You must send an SDLT return to HMRC and pay the tax within 14 days."
+    subtitle_href_scotland: Scotland
+    subtitle_href_wales: Wales.
+    subtitle_href_separator: or 
     href_second_subtitle: "Calculate the LBTT payable."
     url_second_subtitle: "https://www.revenue.scot/land-buildings-transaction-tax/tax-calculators"
     next: Next


### PR DESCRIPTION
[TP10759](https://maps.tpondemand.com/entity/10759-stamp-duty-calculator-copy-changes)

This PR aims to change the text and translations as requested in the ticket for the Stamp Duty Calculator.

A new bug was found in the tooltip where it goes over the tool border making the last paragraph not visible. This is be fixed in [TP10823](https://maps.tpondemand.com/entity/10823-stamp-duty-tooltip-contents-cut-off) so ignore the issue as part of this PR.