### PR TITLE
Add Gemfile.lock back to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle
+Gemfile.lock
 
 # Ignore all logfiles and tempfiles in the dummy app.
 /spec/tmp/*


### PR DESCRIPTION
This was mistakenly removed in a prior commit. As per the conventions of
these frontend engines, ignore the lock file and rely on the gemspec to
declare a loose set of version constraints around dependencies.