### PR TITLE
[DEV APPROVED] 11744 lbtt/ltt/sdlt updates

### DIFF
--- a/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
+++ b/app/assets/javascripts/mortgage_calculator/angular/services/stamp_duty.js
@@ -9,6 +9,7 @@ App.factory('StampDuty', function() {
       secondHomeTaxRate: cfg.second_home_tax_rate || 0,
       firstTimeBuyerThreshold: cfg.first_time_buyer_threshold || 0,
       rates: {
+          higher: cfg.higher || [],
           standard: cfg.standard || [],
           ftb: cfg.ftb || []
       },
@@ -32,6 +33,11 @@ App.factory('StampDuty', function() {
             rates = this.rates.standard;
             $conditionalMessage.addClass('is-active');
           }
+        } else if (cfg.tool === 'ltt' && this.buyerType === 'isSecondHome') {
+          rates = this.rates.higher;
+          $conditionalMessage.removeClass('is-active');
+          $howcalculatedFTB.removeClass('is-active');
+          $howcalculatedNextHome.addClass('is-active');
         } else {
           rates = this.rates.standard;
           $conditionalMessage.removeClass('is-active');
@@ -65,8 +71,14 @@ App.factory('StampDuty', function() {
           }
         }
 
-        if (this.buyerType === 'isSecondHome' && this.propertyPrice >= this.secondHomeTaxThreshold) {
-          totalTax += this.propertyPrice * (this.secondHomeTaxRate / 100);
+        if (cfg.tool === 'ltt') {
+          if (this.buyerType === 'isSecondHome' && this.propertyPrice < this.secondHomeTaxThreshold) {
+            totalTax = 0;
+          }
+        } else {
+          if (this.buyerType === 'isSecondHome' && this.propertyPrice >= this.secondHomeTaxThreshold) {
+            totalTax += this.propertyPrice * (this.secondHomeTaxRate / 100);
+          }
         }
 
         if (cfg.tool === 'ltt') {

--- a/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
@@ -162,6 +162,13 @@
   margin-bottom: 78px;
 }
 
+.mortgagecalc__table__caption {
+  font-size: 1rem; 
+  margin: 0 0 $baseline-unit;
+  text-align: left; 
+  font-weight: 500; 
+}
+
 .mortgagecalc__table__price {
   width: 50%;
 

--- a/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_stamp-duty-calc.scss
@@ -23,10 +23,6 @@
   @include respond-to($mortgagecalc_mq-s) {
     margin-top: $baseline-unit*8;
   }
-
-  .ng-hide {
-    display: none; 
-  }
 }
 
 .stamp-duty__budget-warning {

--- a/app/controllers/mortgage_calculator/land_transaction_taxes_controller.rb
+++ b/app/controllers/mortgage_calculator/land_transaction_taxes_controller.rb
@@ -21,6 +21,11 @@ module MortgageCalculator
     end
     helper_method :standard_rates
 
+    def higher_rates
+      CALCULATOR.banding_for(CALCULATOR::HIGHER_BANDS)
+    end
+    helper_method :higher_rates
+
     def other_countries
       ['england_ni', 'scotland']
     end

--- a/app/helpers/mortgage_calculator/land_transaction_taxes_helper.rb
+++ b/app/helpers/mortgage_calculator/land_transaction_taxes_helper.rb
@@ -21,6 +21,7 @@ module MortgageCalculator
       {
         tool: 'ltt',
         standard: calculator::STANDARD_BANDS,
+        higher: calculator::HIGHER_BANDS,
         second_home_tax_rate: calculator::SECOND_HOME_ADDITIONAL_TAX,
         second_home_threshold: calculator::SECOND_HOME_THRESHOLD
       }.to_json

--- a/app/models/mortgage_calculator/land_and_buildings_transaction_tax.rb
+++ b/app/models/mortgage_calculator/land_and_buildings_transaction_tax.rb
@@ -5,16 +5,14 @@ module MortgageCalculator
     end
 
     FIRST_TIME_BUYER_BANDS = [
-      { threshold: 175_000, rate: 0 },
-      { threshold: 250_000, rate: 2 },
+      { threshold: 250_000, rate: 0 },
       { threshold: 325_000, rate: 5 },
       { threshold: 750_000, rate: 10 },
       { threshold: nil, rate: 12 }
     ].freeze
 
     STANDARD_BANDS = [
-      { threshold: 145_000, rate: 0 },
-      { threshold: 250_000, rate: 2 },
+      { threshold: 250_000, rate: 0 },
       { threshold: 325_000, rate: 5 },
       { threshold: 750_000, rate: 10 },
       { threshold: nil, rate: 12 }

--- a/app/models/mortgage_calculator/land_transaction_tax.rb
+++ b/app/models/mortgage_calculator/land_transaction_tax.rb
@@ -5,25 +5,37 @@ module MortgageCalculator
     end
 
     STANDARD_BANDS = [
-      { threshold: 180_000, rate: 0 },
-      { threshold: 250_000, rate: 3.5 },
+      { threshold: 250_000, rate: 0 },
       { threshold: 400_000, rate: 5 },
       { threshold: 750_000, rate: 7.5 },
       { threshold: 1_500_000, rate: 10 },
       { threshold: nil, rate: 12 }
     ].freeze
 
+    HIGHER_BANDS = [
+      { threshold: 180_000, rate: 3 },
+      { threshold: 250_000, rate: 6.5 },
+      { threshold: 400_000, rate: 8 },
+      { threshold: 750_000, rate: 10.5 },
+      { threshold: 1_500_000, rate: 13 },
+      { threshold: nil, rate: 15 }
+    ].freeze
+
     SECOND_HOME_ADDITIONAL_TAX = 3
+
+    def higher_rate?
+      buyer_type == 'isSecondHome'
+    end
 
     protected
 
     def bands_to_use
-      STANDARD_BANDS
+      higher_rate? ? HIGHER_BANDS : STANDARD_BANDS
     end
 
     def tax_for_band(band_start, band_end, rate)
       return 0 if price < band_start
-      rate += SECOND_HOME_ADDITIONAL_TAX if second_home_taxable?
+      rate = 0 if price < SECOND_HOME_THRESHOLD
       upper_limit = price_in_band?(band_end) ? price : band_end
       amount_to_tax = upper_limit - band_start.floor
       amount_to_tax * rate / 100

--- a/app/views/mortgage_calculator/land_transaction_taxes/_next_home_buyer_explanation.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/_next_home_buyer_explanation.html.erb
@@ -2,6 +2,7 @@
 <p><%= I18n.t("land_transaction_tax.how_calculated_additional") %></p>
 
 <table class="mortgagecalc__table stamp-duty__table">
+  <caption class="mortgagecalc__table__caption"><%= I18n.t("land_transaction_tax.table.caption.main_rate") %></caption>
   <thead>
     <tr>
       <th class="mortgagecalc__table__price">
@@ -9,9 +10,6 @@
       </th>
       <th class="mortgagecalc__table__rate">
         <%= I18n.t("land_transaction_tax.table.rate_header") %>
-      </th>
-      <th class="mortgagecalc__table__extra">
-        <%= I18n.t("land_transaction_tax.table.extra_rate_header") %>
       </th>
     </tr>
   </thead>
@@ -24,8 +22,31 @@
         <td class="mortgagecalc__table__rate">
           <%= rate[:rate] %>%
         </td>
-        <td class="mortgagecalc__table__extra">
-          <%= second_home_rate(rate[:rate]) %>%
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<table class="mortgagecalc__table stamp-duty__table">
+  <caption class="mortgagecalc__table__caption"><%= I18n.t("land_transaction_tax.table.caption.higher_rate") %></caption>
+  <thead>
+    <tr>
+      <th class="mortgagecalc__table__price">
+        <%= I18n.t("land_transaction_tax.table.property_price_header") %>
+      </th>
+      <th class="mortgagecalc__table__rate">
+        <%= I18n.t("land_transaction_tax.table.rate_header") %>*
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% higher_rates.each do |rate| %>
+      <tr>
+        <td class="mortgagecalc__table__price">
+          <%= band(rate[:start], rate[:end]) %>
+        </td>
+        <td class="mortgagecalc__table__rate">
+          <%= rate[:rate] %>%
         </td>
       </tr>
     <% end %>

--- a/app/views/mortgage_calculator/land_transaction_taxes/show.html.erb
+++ b/app/views/mortgage_calculator/land_transaction_taxes/show.html.erb
@@ -4,23 +4,16 @@
   </script>
 <% end %>
 
-<div ng-controller="" class="mortgagecalc__container stamp-duty wal">
+<div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
   <% @ltt.errors.full_messages.each do |message| %>
     <span style="color:red;"><%= message %></span>
   <% end %>
-
-  <div class="stamp-duty__container">
-    <h1 class="stamp-duty__heading"><%= I18n.t("land_transaction_tax.heading") %></h1>
-    <p><%= I18n.t("land_transaction_tax.holding", href: 'https://www.gov.uk/stamp-duty-land-tax').html_safe %></p>
-  </div>
-
   <div wizard on-finish="finishedWizard()" hide-indicators='true'>
     <div wz-step class="ng-hide">
       <div class="stamp-duty__container">
         <h1 class="stamp-duty__heading">
           <%= I18n.t("land_transaction_tax.heading") %>
         </h1>
-
         <h2 class="intro stamp-duty__subheading">
           <%= I18n.t("land_transaction_tax.title") %>
         </h2>

--- a/app/views/mortgage_calculator/property_tax_calculator/_property_tax_to_pay_panel.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/_property_tax_to_pay_panel.html.erb
@@ -26,14 +26,12 @@
               percentage: number_to_percentage(
                 resource.percentage_tax, precision: 2
               )
-        )
-    %>
+        )%>
   </p>
 
   <p class="rendered-from-js stamp-duty__results-tax-rate">
     <%= I18n.t("#{i18n_locale_namespace}.results.sentence_prefix") %>
-    {{ stampDuty.percentageTax() | number: 2 }}
-    <%= I18n.t("#{i18n_locale_namespace}.results.sentence_suffix") %>
+    {{ stampDuty.percentageTax() | number: 2 }}<%= I18n.t("#{i18n_locale_namespace}.results.sentence_suffix") %>
   </p>
 
   <% if outside_first_time_rate? %>

--- a/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
@@ -4,21 +4,14 @@
   </script>
 <% end %>
 
-<div ng-controller="" class="mortgagecalc__container stamp-duty eng/ni_sco">
+<div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
   <% resource.errors.full_messages.each do |m| %>
     <span style="color:red;"><%= m %></span>
   <% end %>
-
-  <div class="stamp-duty__container">
-    <h1 class="stamp-duty__heading"><%= I18n.t("#{i18n_locale_namespace}.heading") %></h1>
-    <p><%= I18n.t("#{i18n_locale_namespace}.holding", href: 'https://www.gov.uk/stamp-duty-land-tax').html_safe %></p>
-  </div>
-
   <div wizard on-finish="finishedWizard()" hide-indicators='true'>
     <div wz-step class="ng-hide">
       <div class="stamp-duty__container">
         <h1 class="stamp-duty__heading"><%= I18n.t("#{i18n_locale_namespace}.heading") %></h1>
-
         <h2 class="intro stamp-duty__subheading"><%= I18n.t("#{i18n_locale_namespace}.title") %></h2>
         <p>
           <%= I18n.t("#{i18n_locale_namespace}.subtitle").html_safe %>

--- a/config/locales/land_and_buildings_transaction_tax.cy.yml
+++ b/config/locales/land_and_buildings_transaction_tax.cy.yml
@@ -15,7 +15,7 @@ cy:
     select:
       label: "Rwy'n"
       option_prompt: "dewiswch opsiwn"
-      option_isNextHome: "prynu fy nghartref nesaf"
+      option_isNextHome: "prynu fy nghartref cyntaf neu fy nghartref nesaf"
       option_isFTB: prynu am y tro cyntaf
       option_isSecondHome: prynu eiddo ychwanegol neu ail gartref
       tooltip_html: Efallai bydd atodiad annedd atodol (ADS) o LBTT yn cael ei gynhwyso i brynu eiddo preswyl o £40,000 neu fwy yn yr Alban. Y gyfradd bresennol ar gyfer ADS yw %{additional_property_rate}% o’r ‘ystyriaeth berthnasol’ (fel arfer y pris prynu).
@@ -29,8 +29,8 @@ cy:
     how_calculated_ftb_3_html: Gall prynwyr tro cyntaf hawlio gostyngiad Prynwr tro Cyntaf. <a href="https://www.moneyadviceservice.org.uk/cy/articles/awgrymiadau-ar-arian-i-brynwyr-tro-cyntaf" target="_blank">Mae rhagor o wybodaeth am beth yw prynwr tro cyntaf ar ein gwefan.</a> Yn ddibynnol ar y pris prynu, gall y gostyngiad hwn leihau eich bil LBTT hyd at £600.
     how_calculated_ftb_4: "Golyga hynny bod cartrefi sydd â phrisiau prynu hyd at %{amount} wedi eu heithrio rhag LBTT fwy neu lai ar gyfer prynwyr tro cyntaf."
     how_calculated_ftb_5: "Er enghraifft:"
-    how_calculated: Mae Treth Trafodiadau Tir ac Adeiladau (LBTT) yn dreth ddatblygol sy'n cael ei chymhwyso i drafodion tir ac adeiladau preswyl lle ceir buddiant trethadwy. Mae'n dâl sy'n fwy cymesur â phris gwirioneddol yr eiddo. Mae'r gyfradd ganrannol ar gyfer pob band yn cael ei chymhwyso i'r rhan o'r pris dros y trothwy perthnasol yn unig a hyd at y trothwy nesaf. Er enghraifft, ni fyddai rhywun sy'n prynu eiddo am £280,000 yn talu unrhyw dreth ar werth yr eiddo hyd at £145,000, treth o 2% ar werth yr eiddo rhwng £145,001 a £250,000 a 5% ar werth yr eiddo rhwng £250,001 a £280,000. Yn yr achos hwn, cyfanswm yr atebolrwydd am Dreth Trafodiad Tir ac Adeiladau (LBTT) fyddai £3,600 gan roi cyfradd dreth effeithiol o 1.29% (cyfradd ganrannol y dreth a dalwyd).
-    how_calculated_additional: "Gall unrhyw un sy'n prynu ail gartref yn yr Alban fod yn atebol am atodiad annedd atodol (ADS) ar brynu eiddo preswyl ychwanegol yn yr Alban o £40,000 neu fwy. Y gyfradd gyfredol yw %{additional_property_rate}% o gyfanswm yr ystyriaeth daladwy (pris yr eiddo fel arfer) ar gyfer eiddo preswyl ychwanegol o £40,000 neu fwy. Er enghraifft, ar gyfer ail gartref o £200,000 byddai'r ADS yn £8,000. Mae'r ADS yn daladwy yn ychwanegol i’r LBTT a fyddai'n ddyledus ar y pryniant. Nodir y cyfraddau a'r bandiau ar gyfer LBTT isod:"
+    how_calculated: "Mae Treth Trafodiad Tir ac Adeiladau (LBTT) yn dreth a gymhwysir i drafodion tir ac adeiladau preswyl ac amhreswyl (gan gynnwys prydlesi masnachol). Mae'r dreth yn daladwy ar wahanol gyfraddau ar bob cyfran o'r pris prynu o fewn bandiau treth penodedig. Dim ond i'r rhan o bris yr eiddo sy'n dod o fewn y band hwnnw y mae'r gyfradd ganrannol ar gyfer pob band yn cael ei chymhwyso. Er enghraifft, ni fyddai rhywun sy'n prynu eiddo am £ 280,000 yn talu unrhyw LBTT ar werth yr eiddo hyd at £250,000 ac yna 5% o'r gwerth rhwng £ 250,000 a £280,000. Yn yr achos hwn, cyfanswm y LBTT a dalwyd fyddai £1,500."
+    how_calculated_additional: "Efallai y bydd yn rhaid i unrhyw un sy'n prynu eiddo preswyl ychwanegol yn yr Alban (fel ail gartref neu eiddo prynu-i-osod) dalu Atodiad Annedd Ychwanegol (ADS) os yw'r pris prynu yn £ 40,000 neu fwy. Yn yr enghraifft uchod, pe bai'r eiddo'n ail gartref, cyfanswm y LBTT a dalwyd fyddai £1,500 PLWS ADS o £11,200 (4% o £280,000), felly cyfanswm o £12,700. Nodir y cyfraddau a'r bandiau ar gyfer LBTT isod:"
     how_calculated_extra: "* Nid yw eiddo dan %{amount} yn destun yr Atodiad Annedd Atodol ar gyfer ail gartref"
     describe_price_field: "Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn."
     activemodel:

--- a/config/locales/land_and_buildings_transaction_tax.cy.yml
+++ b/config/locales/land_and_buildings_transaction_tax.cy.yml
@@ -1,6 +1,5 @@
 cy:
   land_and_buildings_transaction_tax:
-    holding: Mae’r teclyn hwn yn cael ei ddiweddaru ar hyn o bryd. Ewch i <a href="%{href}" target="_blank">gyfrifiannell treth ar dir gov.uk</a> yn y cyfamser
     meta:
       title: "Trafodiadau Tir ac Adeiladau (LBTT) – Cyfrifiannell Treth Stamp yr Alban"
       description: "Defnyddiwch ein cyfrifiannell Treth Trafodiadau Tir ac Adeiladau (LBTT) i gyfrifo faint o LBTT (Treth Stamp yn flaenorol) y bydd angen ichi ei thalu ar eich cartref yn yr Alban"

--- a/config/locales/land_and_buildings_transaction_tax.en.yml
+++ b/config/locales/land_and_buildings_transaction_tax.en.yml
@@ -15,7 +15,7 @@ en:
     select:
       label: I am
       option_prompt: please select an option
-      option_isNextHome: buying my next home
+      option_isNextHome: buying my first or my next home
       option_isFTB: a first-time buyer
       option_isSecondHome: buying an additional property or second home
       tooltip_html: An additional dwelling supplement (ADS) of LBTT may be applied on purchases of additional residential properties in Scotland of £40,000 or more. The current rate for ADS is %{additional_property_rate}% of the ‘relevant consideration’ (usually the purchase price).
@@ -29,8 +29,8 @@ en:
     how_calculated_ftb_3_html: First-time buyers can claim First-time Buyer relief. <a href="https://www.moneyadviceservice.org.uk/en/articles/first-time-buyer-money-tips" target="_blank">You can find out more about what a first-time buyer is on our website.</a> Depending on the purchase price, this relief can reduce your LBTT bill by up to £600.
     how_calculated_ftb_4: "It means that homes with purchase prices up to %{amount} are effectively free from LBTT for first-time buyers."
     how_calculated_ftb_5: "For example:"
-    how_calculated: Land and Buildings Transaction Tax (LBTT) is a progressive tax that is applied to residential land and buildings transactions where a chargeable interest is acquired. It is a charge that is more proportionate to the actual price of the property. The percentage rate for each band is applied only to the part of the price over the relevant threshold and up to the next threshold. For example, someone buying a property for £280,000 would pay no tax on the value of the property up to £145,000, 2% tax on the property value between £145,001 and £250,000 and 5% on the property value between £250,001 and £280,000. In this case, total liability for Land and Buildings Transaction Tax (LBTT) would be £3,600 giving an effective tax rate of 1.29% (average percentage rate of tax paid).
-    how_calculated_additional: "Anyone buying a second home in Scotland may be liable for an additional dwelling supplement (ADS) on purchases of additional residential properties in Scotland of £40,000 or more. The current rate is %{additional_property_rate}% of the total chargeable consideration (usually the property price) for an additional residential property of £40,000 or more. For example, for a £200,000 second home the ADS would be £8,000. The ADS is payable in addition to the LBTT that would be due on the purchase. The rates and bands for LBTT are set out below:"
+    how_calculated: "Land and Buildings Transaction Tax (LBTT) is a tax applied to residential and non-residential land and buildings transactions (including commercial leases). The tax is payable at different rates on each portion of the purchase price within specified tax bands. The percentage rate for each band is applied only to the part of the property price that falls within that band. For example, someone buying a property for £280,000 would pay no LBTT on the value of the property up to £250,000 and then 5% of the value between £250,000 and £280,000. In this case the total LBTT paid would be £1,500."
+    how_calculated_additional: "Anyone buying an additional residential property in Scotland (such as a second home or a buy-to-let property) may also have to pay an Additional Dwelling Supplement (ADS) if the purchase price is £40,000 or more. In the example above, if the property was a second home the total amount of LBTT paid would be £1,500 PLUS ADS of £11,200 (4% of £280,000), so £12,700 in total. The rates and bands for LBTT are set out below:"
     how_calculated_extra: "* Properties under %{amount} are not subject to second home Additional Dwelling Supplement"
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:

--- a/config/locales/land_and_buildings_transaction_tax.en.yml
+++ b/config/locales/land_and_buildings_transaction_tax.en.yml
@@ -1,6 +1,5 @@
 en:
   land_and_buildings_transaction_tax:
-    holding: This tool is currently undergoing maintenance. Please visit the <a href="%{href}" target="_blank">gov.uk land tax calculator</a> in the meantime.
     meta:
       title: "Land and Buildings Transaction Tax (LBTT) – Scottish Stamp Duty calculator"
       description: "Use our Land and Buildings Transaction Tax (LBTT) calculator to calculate how much LBTT (formerly Stamp Duty) you’ll need to pay on your home in Scotland"

--- a/config/locales/land_transaction_tax.cy.yml
+++ b/config/locales/land_transaction_tax.cy.yml
@@ -1,6 +1,5 @@
 cy:
   land_transaction_tax:
-    holding: Mae’r teclyn hwn yn cael ei ddiweddaru ar hyn o bryd. Ewch i <a href="%{href}" target="_blank">gyfrifiannell treth ar dir gov.uk</a> yn y cyfamser
     meta:
       title: "Treth Trafodiadau Tir (LTT) - Cyfrifiannell Treth Stamp Cymru"
       description: "Defnyddiwch ein cyfrifiannell Treth Trafodiadau Tir (LTT) i gyfrifo faint o LTT (Treth Stamp yn flaenorol) y bydd angen ichi ei thalu ar eich cartref yn yr Alban"

--- a/config/locales/land_transaction_tax.cy.yml
+++ b/config/locales/land_transaction_tax.cy.yml
@@ -15,7 +15,7 @@ cy:
     select:
       label: "Rwy'n"
       option_prompt: "dewiswch opsiwn"
-      option_isNextHome: "prynu fy nghartref nesaf"
+      option_isNextHome: "prynu fy nghartref cyntaf neu fy nghartref nesaf"
       option_isSecondHome: "prynu eiddo ychwanegol neu ail gartref"
       tooltip_html: "Fel arfer bydd yn rhaid i chi dalu cyfraddau uwch o Dreth Trafodiad Tir os ydych yn prynu eiddo preswyl sy'n werth %{amount} neu fwy ac eisoes yn berchen ar 1 eiddo neu fwy."
     recalculate: Ailgyfrifo
@@ -24,9 +24,9 @@ cy:
       title: "Prynu yn Lloegr, Gogledd Iwerddon neu'r Alban?"
       body: "Os ydych chi'n prynu yn unrhyw un o'r gwledydd hyn, yna defnyddiwch y gyfrifiannell briodol i gyfrifo faint fyddwch chi'n ei dalu:"
     how_calculated_toggle: "Sut y cyfrifir hyn?"
-    how_calculated: "Telir Treth Trafodiad Tir (LTT) ar y brif gyfradd treth a chyfradd uwch. Mae hyn fel arfer yn seiliedig ar y pris rydych yn ei dalu am yr eiddo neu'r tir, ond gallai gynnwys mathau eraill o daliad fel nwyddau, gwaith neu wasanaethau, rhyddhau o ddyled, neu drosglwyddo dyled, gan gynnwys gwerth unrhyw forgais sy'n ddyledus. Er enghraifft, ni fyddai rhywun sy'n prynu eiddo am £280,000 yn talu unrhyw dreth ar werth yr eiddo hyd at £180,000, treth o 3.5% ar werth yr eiddo rhwng £180,001 a £250,000 a 5% ar werth yr eiddo rhwng £250,001 a £280,000. Yn yr achos hwn, cyfanswm yr atebolrwydd am Dreth Trafodiad Tir (LTT) fyddai £3,950 gan roi cyfradd dreth effeithiol o 1.41% (cyfradd ganrannol y dreth a dalwyd)."
+    how_calculated: "Telir Treth Trafodiad Tir (LTT) ar brif gyfraddau treth ac uwch. Mae hyn fel arfer yn seiliedig ar y pris rydych chi'n ei dalu am yr eiddo neu'r tir, ond gallai gynnwys mathau eraill o daliad fel nwyddau, gwaith neu wasanaethau, rhyddhau o ddyled, neu drosglwyddo dyled, gan gynnwys gwerth unrhyw forgais sy'n ddyledus. Er enghraifft, ni fyddai rhywun sy'n prynu eiddo am £280,000 yn talu unrhyw dreth ar werth yr eiddo hyd at  £250,000 a 5% ar y gwerth rhwng £250,000 a £280,000. Yn yr achos hwn, cyfanswm yr atebolrwydd am Dreth Trafodiad Tir (LTT) fyddai £1,500."
  
-    how_calculated_additional: "Efallai y bydd yn rhaid i unrhyw un sy'n prynu eiddo ychwanegol dalu cyfradd uwch o LTT. Yn yr enghraifft hon, byddai hynny'n cynrychioli £8,400 ychwanegol, sy'n golygu mai cyfanswm y Treth Trafodiadau Tir fyddai £12,350 gan roi cyfradd dreth effeithiol o 4.41%. Os ydych yn amnewid eich prif breswylfa efallai na fydd y cyfraddau uwch yn berthnasol. Os ydych yn amnewid eich prif breswylfa efallai na fydd y cyfraddau uwch yn berthnasol."
+    how_calculated_additional: "Efallai y bydd yn rhaid i unrhyw un sy'n prynu eiddo ychwanegol dalu cyfradd uwch o LTT. Yn yr enghraifft hon, byddai LTT o 3% yn ddyledus ar werth yr eiddo hyd at £180,000 (£5,400), 6.5% ar y gwerth rhwng £180,000 a £ 250,000 (£4,550) ac 8% ar y gwerth rhwng £ 250,000 a  £280,000 (£2,400) sy'n golygu mai cyfanswm y LTT sy'n ddyledus fyddai £12,350. Os ydych chi'n amnewid eich prif breswylfa, efallai na fydd y cyfraddau uwch yn berthnasol."
 
     how_calculated_extra: "* Nid yw prynu eiddo o dan %{amount} yn destun i gyfraddau uwch o Treth Trafodiad Tir (LTT)"
     describe_price_field: "Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn."
@@ -46,6 +46,9 @@ cy:
       rate_header: "Cyfradd Treth Trafodion Tir ac Adeiladau (LBTT)"
       extra_rate_header: "Cyfradd LTT Uwch*"
       max: "%{value}+"
+      caption:
+        main_rate: Prif gyfraddau preswyl Treth Trafodiadau Tir (LTT)
+        higher_rate: Cyfraddau preswyl uwch Treth Trafodiadau Tir (LTT)
     next_steps:
       learn_more:
         title: "A wyddech chi?"

--- a/config/locales/land_transaction_tax.en.yml
+++ b/config/locales/land_transaction_tax.en.yml
@@ -15,7 +15,7 @@ en:
     select:
       label: I am
       option_prompt: please select an option
-      option_isNextHome: buying my next home
+      option_isNextHome: buying my first or my next home
       option_isSecondHome: buying an additional property or second home
       tooltip_html: "You will usually have to pay higher rates of Land Transaction Tax if you are buying a residential property worth %{amount} or more and already own 1 or more properties."
     recalculate: Recalculate
@@ -23,11 +23,9 @@ en:
       title: "Buying in England, Northern Ireland or Scotland?"
       body: "If you are buying in any of these countries then use the appropriate calculator to work out how much you will pay"
     how_calculated_toggle: "How is this calculated?"
-    how_calculated: "Land Transaction Tax (LTT) is paid at both main and higher rates of tax.  This is usually based on the price you pay for the property or land, but it might include other types of payment such as goods, works or services, release from a debt, or transfer of a debt, including the value of any outstanding mortgage. For example, someone buying a property for £280,000 would pay no tax on the value of the property up to £180,000, 3.5% tax on the property value between £180,001 and £250,000 and 5% on the property value between £250,001 and £280,000. In this case, total liability for Land Transaction Tax (LTT) would be £3,950 giving an effective tax rate of 1.41% (average percentage rate of tax paid)."
+    how_calculated: "Land Transaction Tax (LTT) is paid at both main and higher rates of tax.  This is usually based on the price you pay for the property or land, but it might include other types of payment such as goods, works or services, release from a debt, or transfer of a debt, including the value of any outstanding mortgage.  For example, someone buying a property for £280,000 would pay no tax on the value of the property up to £250,000  and 5% on the value between £250,000 and £280,000.  In this case, total liability for Land Transaction Tax (LTT) would be £1,500."
 
-    how_calculated_additional: "Anyone buying additional property may have to pay a higher rate of LTT. In this example that would represent an extra £8,400, meaning the total Land Transaction Tax would be £12,350 giving an effective tax rate of 4.41%. If you are replacing your main residence the higher rates may not apply.
-
-"
+    how_calculated_additional: "Anyone buying additional property may have to pay a higher rate of LTT.  In this example LTT of 3% would be due on the value of the property up to £180,000 (£5,400), 6.5% on the value between £180,000 and £250,000 (£4,550) and 8% on the value between £250,000 and £280,000 (£2,400) meaning the total LTT due would be £12,350.  If you are replacing your main residence, the higher rates may not apply."
 
     how_calculated_extra: "* Buying a residential property under %{amount} is not subject to higher rates of Land Transaction Tax (LTT)"
     describe_price_field: Make sure to clear the existing number before entering the new number.
@@ -47,6 +45,9 @@ en:
       rate_header: "Rate of Land Transaction Tax"
       extra_rate_header: "Higher LTT Rate*"
       max: "%{value}+"
+      caption:
+        main_rate: Main residential LTT rates
+        higher_rate: Higher residential LTT rates
     next_steps:
       learn_more:
         title: "Did you know?"

--- a/config/locales/land_transaction_tax.en.yml
+++ b/config/locales/land_transaction_tax.en.yml
@@ -1,6 +1,5 @@
 en:
   land_transaction_tax:
-    holding: This tool is currently undergoing maintenance. Please visit the <a href="%{href}" target="_blank">gov.uk land tax calculator</a> in the meantime.
     meta:
       title: "Land Transaction Tax (LTT) - Welsh Stamp Duty Calculator"
       description: "Use our Land Transaction Tax (LTT) calculator to calculate how much LTT (formerly Stamp Duty) you'll need to pay on your home in Scotland"

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -16,7 +16,7 @@ cy:
     select:
       label: Rwy'n
       option_prompt: dewiswch opsiwn
-      option_isNextHome: prynu fy nghartref nesaf
+      option_isNextHome: prynu fy nghartref cyntaf neu fy nghartref nesaf
       option_isFTB: prynu am y tro cyntaf
       option_isSecondHome: prynu eiddo ychwanegol neu ail gartref
       tooltip_html: Mae'n rhaid i chi dalu Treth Tir Treth Stamp (SDLT) os ydych yn prynu eiddo neu dir dros bris penodol yn Lloegr a Gogledd Iwerddon. Mae yna reolau gwahanol os ydych yn prynu eiddo ychwanegol. <br /><br />Yn gyffredinol rhaid i chi dalu'r cyfraddau SDLT uwch pan brynwch eiddo preswyl neu ran o un os nad hwnnw fydd yr unig eiddo preswyl yr ydych yn berchen arno (neu'n berchen ar y cyd) yn unrhyw le yn y byd, os nad ydych wedi gwerthu neu roi eich prif gartref blaenorol i rywun ac nid oes gan neb les arno sydd â mwy na 21 mlynedd yn weddill. Mae'r rheolau hyn yn berthnasol os ydych yn briod neu'n prynu ar y cyd a'r unigolyn hwnnw neu honno.

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -1,6 +1,5 @@
 cy:
   stamp_duty:
-    holding: Mae’r teclyn hwn yn cael ei ddiweddaru ar hyn o bryd. Ewch i <a href="%{href}" target="_blank">gyfrifiannell treth ar dir gov.uk</a> yn y cyfamser
     meta:
       title: "Cyfrifiannell Treth Stamp - Cyfrifwch y cyfraddau newydd a ddiweddarwyd ar gyfer Treth Dir y Doll Stamp"
       description: "Defnyddiwch ein cyfrifiannell Treth Stamp i gael amcangyfrif o faint o Dreth Dir y Doll Stamp y bydd angen i chi ei thalu ar eich cartref newydd yn seiliedig ar y cyfraddau newydd a ddiweddarwyd"

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -1,6 +1,5 @@
 en:
   stamp_duty:
-    holding: This tool is currently undergoing maintenance. Please visit the <a href="%{href}" target="_blank">gov.uk land tax calculator</a> in the meantime.
     meta:
       title: "Stamp Duty Calculator - Work out the new updated Stamp Duty Land Tax rates"
       description: "Use our Stamp Duty calculator to get an estimate of how much Stamp Duty Land Tax you’ll need to pay on your new home based on the new updated rates"

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -16,7 +16,7 @@ en:
     select:
       label: I am
       option_prompt: please select an option
-      option_isNextHome: buying my next home
+      option_isNextHome: buying my first or my next home
       option_isFTB: a first-time buyer
       option_isSecondHome: buying an additional property or second home
       tooltip_html: You must pay Stamp Duty Land Tax (SDLT) if you buy a property or land over a certain price in England and Northern Ireland. There are different rules if you’re buying an additional property. <br /><br />You must generally pay the higher SDLT rates when you buy a residential property or a part of one if it will not be the only residential property that you own (or part own) anywhere in the world, you have not sold or given away your previous main home and no one else has a lease on it which has more than 21 years left to run. These rules apply if you’re married to or buying with someone.

--- a/features/analytics.feature
+++ b/features/analytics.feature
@@ -9,11 +9,11 @@ Scenario: When a user uses the mortgage calculator
   When  I have entered some details into the repayment tool
   Then  My repayment completion interaction is tracked
 
-# Scenario: When a user uses the stamp duty calculator
-#   Given I visit the stamp duty calculator
-#   And I select to calculate for a second home
-#   When  I enter my house price
-#   Then  My stamp duty completion interaction is tracked
+Scenario: When a user uses the stamp duty calculator
+  Given I visit the stamp duty calculator
+  And I select to calculate for a second home
+  When  I enter my house price
+  Then  My stamp duty completion interaction is tracked
 
 Scenario: When a user uses the mortgage calculator
   Given I visit the Repayment calculator

--- a/features/land_buildings_transaction_tax_calculator.feature
+++ b/features/land_buildings_transaction_tax_calculator.feature
@@ -27,13 +27,13 @@ Feature: Land and Buildings Transaction Tax Calculator
     | 550000  | 28,350 | 5.15%         |
     | 901000  | 66,470 | 7.38%         |
 
-#  @javascript
-#  Scenario Outline: tax for next home
-#    When I enter a house price of <price>
-#    And I am a next home buyer
-#    And I click next
-#    Then I see the call out box with everything I need to know
-#    And I see the stamp duty I will have to pay is "£<duty>"
+  @javascript
+  Scenario Outline: tax for next home
+    When I enter a house price of <price>
+    And I am a next home buyer
+    And I click next
+    Then I see the call out box with everything I need to know
+    And I see the stamp duty I will have to pay is "£<duty>"
 
   Examples:
     | price   | duty   | effective tax |
@@ -58,15 +58,15 @@ Feature: Land and Buildings Transaction Tax Calculator
     And I see the stamp duty I will have to pay is "£15,950"
     And I see the effective tax rate is "3.74%"
 
-#  @javascript
-#  Scenario: I recalculate for next home
-#    When I enter a house price of 260000
-#    And I am a next home buyer
-#    And I click next
-#    And I see the stamp duty I will have to pay is "£2,600"
-#    Then I reenter my house price with "426000"
-#    And I click next again
-#    And I see the stamp duty I will have to pay is "£15,950"
+  @javascript
+  Scenario: I recalculate for next home
+    When I enter a house price of 260000
+    And I am a next home buyer
+    And I click next
+    And I see the stamp duty I will have to pay is "£2,600"
+    Then I reenter my house price with "426000"
+    And I click next again
+    And I see the stamp duty I will have to pay is "£15,950"
 
   Scenario Outline: Buy to let buyer
     Given I am buying an additional property or second home

--- a/features/land_buildings_transaction_tax_calculator.feature
+++ b/features/land_buildings_transaction_tax_calculator.feature
@@ -15,17 +15,16 @@ Feature: Land and Buildings Transaction Tax Calculator
     And I see the effective tax rate is "<effective tax>"
 
   Examples:
-    | price   | duty   | effective tax |
-    | 39000   | 0      | 0.00%         |
-    | 40000   | 0      | 0.00%         |
-    | 120000  | 0      | 0.00%         |
-    | 126000  | 0      | 0.00%         |
-    | 260000  | 2,600  | 1.00%         |
-    | 300019  | 4,600  | 1.53%         |
-    | 350000  | 8,350  | 2.39%         |
-    | 450000  | 18,350 | 4.08%         |
-    | 550000  | 28,350 | 5.15%         |
-    | 901000  | 66,470 | 7.38%         |
+    | price  | duty   | effective tax |
+    | 39000  | 0      | 0.00%         |
+    | 40000  | 0      | 0.00%         |
+    | 120000 | 0      | 0.00%         |
+    | 260000 | 500    | 0.19%         |
+    | 300019 | 2,500  | 0.83%         |
+    | 350000 | 6,250  | 1.79%         |
+    | 450000 | 16,250 | 3.61%         |
+    | 550000 | 26,250 | 4.77%         |
+    | 901000 | 64,370 | 7.14%         |
 
   @javascript
   Scenario Outline: tax for next home
@@ -36,37 +35,36 @@ Feature: Land and Buildings Transaction Tax Calculator
     And I see the stamp duty I will have to pay is "£<duty>"
 
   Examples:
-    | price   | duty   | effective tax |
-    | 39000   | 0      | 0.00%         |
-    | 40000   | 0      | 0.00%         |
-    | 120000  | 0      | 0.00%         |
-    | 126000  | 0      | 0.00%         |
-    | 260000  | 2,600  | 1.00%         |
-    | 300019  | 4,600  | 1.53%         |
-    | 350000  | 8,350  | 2.39%         |
-    | 450000  | 18,350 | 4.08%         |
-    | 550000  | 28,350 | 5.15%         |
-    | 901000  | 66,470 | 7.38%         |
+    | price  | duty   | effective tax |
+    | 39000  | 0      | 0.00%         |
+    | 40000  | 0      | 0.00%         |
+    | 120000 | 0      | 0.00%         |
+    | 260000 | 500    | 0.19%         |
+    | 300019 | 2,500  | 0.83%         |
+    | 350000 | 6,250  | 1.79%         |
+    | 450000 | 16,250 | 3.61%         |
+    | 550000 | 26,250 | 4.77%         |
+    | 901000 | 64,370 | 7.14%         |
 
   Scenario: I recalculate for next home
-    When I enter a house price of 260000
+    When I enter a house price of 280000
     And I am a next home buyer
     And I click next
-    And I see the stamp duty I will have to pay is "£2,600"
+    And I see the stamp duty I will have to pay is "£1,500"
     Then I reenter my house price with "426000"
     And I click next again
-    And I see the stamp duty I will have to pay is "£15,950"
-    And I see the effective tax rate is "3.74%"
+    And I see the stamp duty I will have to pay is "£13,850"
+    And I see the effective tax rate is "3.25%"
 
   @javascript
   Scenario: I recalculate for next home
-    When I enter a house price of 260000
+    When I enter a house price of 280000
     And I am a next home buyer
     And I click next
-    And I see the stamp duty I will have to pay is "£2,600"
+    And I see the stamp duty I will have to pay is "£1,500"
     Then I reenter my house price with "426000"
     And I click next again
-    And I see the stamp duty I will have to pay is "£15,950"
+    And I see the stamp duty I will have to pay is "£13,850"
 
   Scenario Outline: Buy to let buyer
     Given I am buying an additional property or second home
@@ -81,6 +79,24 @@ Feature: Land and Buildings Transaction Tax Calculator
       | 35000   | 0       | 0.00     |
       | 40000   | 1,600   | 4.00     |
       | 125000  | 5,000   | 4.00     |
-      | 350000  | 22,350  | 6.39     |
-      | 750000  | 78,350  | 10.45    |
-      | 1223300 | 154,078 | 12.60    |
+      | 350000  | 20,250  | 5.79     |
+      | 750000  | 76,250  | 10.17    |
+      | 1223300 | 151,978 | 12.42    |
+
+  @javascript
+  Scenario Outline: Buy to let buyer
+    Given I am buying an additional property or second home
+    When I enter a house price of <price>
+    And I click next
+    Then I see the call out box with everything I need to know
+    And I see the stamp duty I will have to pay is "£<duty>"
+    And I should see the tax rate being used is "<tax_rate>%"
+
+    Examples:
+      | price   | duty    | tax_rate |
+      | 35000   | 0       | 0.00     |
+      | 40000   | 1,600   | 4.00     |
+      | 125000  | 5,000   | 4.00     |
+      | 350000  | 20,250  | 5.79     |
+      | 750000  | 76,250  | 10.17    |
+      | 1223300 | 151,978 | 12.42    |

--- a/features/land_transaction_tax_calculator.feature
+++ b/features/land_transaction_tax_calculator.feature
@@ -24,12 +24,12 @@ Feature: Land Transaction Tax Calculator
     | 800000  | 41,200     | 5.15%         |
     | 2000000 | 171,200    | 8.56%         |
 
-#  @javascript
-#  Scenario Outline: tax for next home
-#    When I enter a house price of <price>
-#    And I am a next home buyer
-#    And I click next
-#    Then I see the stamp duty I will have to pay is "£<duty>"
+  @javascript
+  Scenario Outline: tax for next home
+    When I enter a house price of <price>
+    And I am a next home buyer
+    And I click next
+    Then I see the stamp duty I will have to pay is "£<duty>"
 
   Examples:
     | price   | duty       | effective tax |
@@ -52,15 +52,15 @@ Feature: Land Transaction Tax Calculator
     And I see the stamp duty I will have to pay is "£11,900"
     And I see the effective tax rate is "2.79%"
 
-#  @javascript
-#  Scenario: I recalculate for next home
-#    When I enter a house price of 260000
-#    And I am a next home buyer
-#    And I click next
-#    And I see the stamp duty I will have to pay is "£2,950.00"
-#    Then I reenter my house price with "333333"
-#    And I click next again
-#    And I see the stamp duty I will have to pay is "£6,616.65"
+  @javascript
+  Scenario: I recalculate for next home
+    When I enter a house price of 260000
+    And I am a next home buyer
+    And I click next
+    And I see the stamp duty I will have to pay is "£2,950.00"
+    Then I reenter my house price with "333333"
+    And I click next again
+    And I see the stamp duty I will have to pay is "£6,616.65"
 
   Scenario Outline: Buy to let buyer
     Given I am buying an additional property or second home 

--- a/features/land_transaction_tax_calculator.feature
+++ b/features/land_transaction_tax_calculator.feature
@@ -18,11 +18,11 @@ Feature: Land Transaction Tax Calculator
     | 39000   | 0          | 0.00%         |
     | 40000   | 0          | 0.00%         |
     | 179000  | 0          | 0.00%         |
-    | 260000  | 2,950      | 1.13%         |
-    | 333333  | 6,616      | 1.98%         |
-    | 467895  | 15,042     | 3.21%         |
-    | 800000  | 41,200     | 5.15%         |
-    | 2000000 | 171,200    | 8.56%         |
+    | 260000  | 500        | 0.19%         |
+    | 333333  | 4,166      | 1.25%         |
+    | 467895  | 12,592     | 2.69%         |
+    | 800000  | 38,750     | 4.84%         |
+    | 2000000 | 168,750    | 8.44%         |
 
   @javascript
   Scenario Outline: tax for next home
@@ -36,31 +36,31 @@ Feature: Land Transaction Tax Calculator
     | 39000   | 0          | 0.00%         |
     | 40000   | 0          | 0.00%         |
     | 179000  | 0          | 0.00%         |
-    | 260000  | 2,950      | 1.13%         |
-    | 333333  | 6,616.65   | 1.98%         |
-    | 467895  | 15,042.13  | 3.21%         |
-    | 800000  | 41,200     | 5.15%         |
-    | 2000000 | 171,200    | 8.56%         |
+    | 260000  | 500        | 0.19%         |
+    | 333333  | 4,166      | 1.25%         |
+    | 467895  | 12,592     | 2.69%         |
+    | 800000  | 38,750     | 4.84%         |
+    | 2000000 | 168,750    | 8.44%         |
 
   Scenario: I recalculate for next home
     When I enter a house price of 260000
     And I am a next home buyer
     And I click next
-    And I see the stamp duty I will have to pay is "£2,950"
+    And I see the stamp duty I will have to pay is "£500"
     Then I reenter my house price with "426000"
     And I click next again
-    And I see the stamp duty I will have to pay is "£11,900"
-    And I see the effective tax rate is "2.79%"
+    And I see the stamp duty I will have to pay is "£9,450"
+    And I see the effective tax rate is "2.22%"
 
   @javascript
   Scenario: I recalculate for next home
     When I enter a house price of 260000
     And I am a next home buyer
     And I click next
-    And I see the stamp duty I will have to pay is "£2,950.00"
+    And I see the stamp duty I will have to pay is "£500"
     Then I reenter my house price with "333333"
     And I click next again
-    And I see the stamp duty I will have to pay is "£6,616.65"
+    And I see the stamp duty I will have to pay is "£4,166.65"
 
   Scenario Outline: Buy to let buyer
     Given I am buying an additional property or second home 
@@ -68,6 +68,23 @@ Feature: Land Transaction Tax Calculator
     And I click next
     And I see the stamp duty I will have to pay is "£<duty>"
     And I see the effective tax rate is "<effective tax>"
+
+    Examples:
+      | price   | duty     | effective tax |
+      | 35000   | 0        | 0.00%         |
+      | 135588  | 4,067    | 3.00%         |
+      | 180000  | 5,400    | 3.00%         |
+      | 260000  | 10,750   | 4.13%         |
+      | 500000  | 32,450   | 6.49%         |
+      | 900000  | 78,200   | 8.69%         |
+      | 1800000 | 201,200  | 11.18%        |
+
+  @javascript
+  Scenario Outline: Buy to let buyer
+    Given I am buying an additional property or second home 
+    When I enter a house price of <price>
+    And I click next
+    And I see the stamp duty I will have to pay is "£<duty>"
 
     Examples:
       | price   | duty     | effective tax |

--- a/features/lbtt_how_calculated_panel.feature
+++ b/features/lbtt_how_calculated_panel.feature
@@ -25,8 +25,7 @@ Scenario: LBTT How is this calculated panel - Next home buyer journey
   And I click on the How is this Calculated information icon
   Then I should see the values on the information panel as:
   | Purchase price      | Rate of Land and Buildings Transaction Tax (LBTT) | Buy to Let/ Additional Dwelling Supplement (ADS)* |
-  | Up to £145,000      | 0%                 | 4%                           |
-  | £145,001 - £250,000 | 2%                 | 4%                           |
+  | Up to £250,000      | 0%                 | 4%                           |
   | £250,001 - £325,000 | 5%                 | 4%                           |
   | £325,001 - £750,000 | 10%                | 4%                           |
   | Over £750,000       | 12%                | 4%                           |
@@ -38,8 +37,7 @@ Scenario: LBTT How is this calculated panel - Additional home buyer journey
   And I click on the How is this Calculated information icon
   Then I should see the values on the information panel as:
   | Purchase price      | Rate of Land and Buildings Transaction Tax (LBTT) | Buy to Let/ Additional Dwelling Supplement (ADS)* |
-  | Up to £145,000      | 0%                 | 4%                           |
-  | £145,001 - £250,000 | 2%                 | 4%                           |
+  | Up to £250,000      | 0%                 | 4%                           |
   | £250,001 - £325,000 | 5%                 | 4%                           |
   | £325,001 - £750,000 | 10%                | 4%                           |
   | Over £750,000       | 12%                | 4%                           |

--- a/features/stamp_duty_buying_next_home.feature
+++ b/features/stamp_duty_buying_next_home.feature
@@ -1,69 +1,69 @@
 Feature: Stamp Duty - Next Home Buyer
-  So that I know how much stamp duty to pay
-  As a user buying my next home
-  I want to enter my house price
+So that I know how much stamp duty to pay
+As a user buying my next home
+I want to enter my house price
 
-  Background:
-    Given I visit the Stamp Duty page
+Background:
+  Given I visit the Stamp Duty page
 
-#   Scenario Outline: stamp duty for next home
-#     When I enter a house price of <price>
-#     And I am a next home buyer
-#     And I click next
-#     Then I see the title for the results page
-#     And I see the stamp duty I will have to pay is "£<duty>"
-#     And I see the effective tax rate is "<effective tax>"
+Scenario Outline: stamp duty for next home
+  When I enter a house price of <price>
+  And I am a next home buyer
+  And I click next
+  Then I see the title for the results page
+  And I see the stamp duty I will have to pay is "£<duty>"
+  And I see the effective tax rate is "<effective tax>"
 
-#   Examples:
-#     | price   | duty    | effective tax |
-#     | 39000   | 0       | 0.00%         |
-#     | 40000   | 0       | 0.00%         |
-#     | 120000  | 0       | 0.00%         |
-#     | 126000  | 0       | 0.00%         |
-#     | 260000  | 0       | 0.00%         |
-#     | 300019  | 0       | 0.00%         |
-#     | 350000  | 0       | 0.00%         |
-#     | 450000  | 0       | 0.00%         |
-#     | 550000  | 2,500   | 0.45%         |
-#     | 650000  | 7,500   | 1.15%         |
+Examples:
+  | price   | duty    | effective tax |
+  | 39000   | 0       | 0.00%         |
+  | 40000   | 0       | 0.00%         |
+  | 120000  | 0       | 0.00%         |
+  | 126000  | 0       | 0.00%         |
+  | 260000  | 0       | 0.00%         |
+  | 300019  | 0       | 0.00%         |
+  | 350000  | 0       | 0.00%         |
+  | 450000  | 0       | 0.00%         |
+  | 550000  | 2,500   | 0.45%         |
+  | 650000  | 7,500   | 1.15%         |
 
-  # @javascript
-  # Scenario Outline: stamp duty for next home
-  #   When I enter a house price of <price>
-  #   And I am a next home buyer
-  #   And I click next
-  #   Then I see the title for the results page
-  #   Then I see the stamp duty I will have to pay is "£<duty>"
+@javascript
+Scenario Outline: stamp duty for next home
+  When I enter a house price of <price>
+  And I am a next home buyer
+  And I click next
+  Then I see the title for the results page
+  Then I see the stamp duty I will have to pay is "£<duty>"
 
-#   Examples:
-#     | price   | duty   |
-#     | 39000   | 0      |
-#     | 40000   | 0      |
-#     | 120000  | 0      |
-#     | 126000  | 0      |
-#     | 260000  | 0      |
-#     | 350000  | 0      |
-#     | 400012  | 0      |
-#     | 450000  | 0      |
-#     | 550000  | 2,500  |
-#     | 750000  | 12,500 |
-#     | 1500000 | 78,750 |
+Examples:
+  | price   | duty   |
+  | 39000   | 0      |
+  | 40000   | 0      |
+  | 120000  | 0      |
+  | 126000  | 0      |
+  | 260000  | 0      |
+  | 350000  | 0      |
+  | 400012  | 0      |
+  | 450000  | 0      |
+  | 550000  | 2,500  |
+  | 750000  | 12,500 |
+  | 1500000 | 78,750 |
 
-  Scenario: I recalculate for next home
-    When I enter a house price of 550000
-    And I am a next home buyer
-    And I click next
-    And I see the stamp duty I will have to pay is "£2,500"
-    Then I reenter my house price with "126000"
-    And I click next again
-    And I see the stamp duty I will have to pay is "£0"
+Scenario: I recalculate for next home
+  When I enter a house price of 550000
+  And I am a next home buyer
+  And I click next
+  And I see the stamp duty I will have to pay is "£2,500"
+  Then I reenter my house price with "126000"
+  And I click next again
+  And I see the stamp duty I will have to pay is "£0"
 
-  # @javascript
-  # Scenario: I recalculate for next home
-  #   When I enter a house price of 550000
-  #   And I am a next home buyer
-  #   And I click next
-  #   And I see the stamp duty I will have to pay is "£2,500"
-  #   Then I reenter my house price with "126000"
-  #   And I click next again
-  #   And I see the stamp duty I will have to pay is "£0"
+@javascript
+Scenario: I recalculate for next home
+  When I enter a house price of 550000
+  And I am a next home buyer
+  And I click next
+  And I see the stamp duty I will have to pay is "£2,500"
+  Then I reenter my house price with "126000"
+  And I click next again
+  And I see the stamp duty I will have to pay is "£0"

--- a/features/stamp_duty_buying_second_home.feature
+++ b/features/stamp_duty_buying_second_home.feature
@@ -3,30 +3,30 @@ So that I know how much stamp duty to pay
 As a user buying a second house
 I want to enter my house price
 
-# @javascript
-# Scenario Outline: stamp duty for second home
-#   Given I visit the Stamp Duty page
-#   When I enter a house price of <price>
-#   And I select to calculate for a second home
-#   And I click next
-#   Then I see the title for the results page
-#   Then I see the stamp duty I will have to pay is "£<duty>"
+@javascript
+Scenario Outline: stamp duty for second home
+  Given I visit the Stamp Duty page
+  When I enter a house price of <price>
+  And I select to calculate for a second home
+  And I click next
+  Then I see the title for the results page
+  Then I see the stamp duty I will have to pay is "£<duty>"
 
-# Examples:
-#   | price   | duty    |
-#   | 39000   | 0       |
-#   | 40000   | 1,200   |
-#   | 120000  | 3,600   |
-#   | 126000  | 3,780   |
-#   | 260000  | 7,800   |
-#   | 510000  | 15,800  |
-#   | 988882  | 57,304  |
-#   | 1100000 | 71,750  |
-#   | 2100000 | 213,750 |
-#   | 450000  | 13,500  |
-#   | 500000  | 15,000  |
-#   | 577888  | 21,231  |
-#   | 1440000 | 115,950 |
+Examples:
+  | price   | duty    |
+  | 39000   | 0       |
+  | 40000   | 1,200   |
+  | 120000  | 3,600   |
+  | 126000  | 3,780   |
+  | 260000  | 7,800   |
+  | 510000  | 15,800  |
+  | 988882  | 57,304  |
+  | 1100000 | 71,750  |
+  | 2100000 | 213,750 |
+  | 450000  | 13,500  |
+  | 500000  | 15,000  |
+  | 577888  | 21,231  |
+  | 1440000 | 115,950 |
 
 Scenario Outline: stamp duty for second home
   Given I visit the Stamp Duty page
@@ -62,13 +62,13 @@ Scenario: I recalculate for second home
   And I click next again
   And I see the stamp duty I will have to pay is "£3,780"
 
-# @javascript
-# Scenario: I recalculate for second home
-#   Given I visit the Stamp Duty page
-#   When I enter my house price with "260000"
-#   And I select to calculate for a second home
-#   And I click next
-#   And I see the stamp duty I will have to pay is "£7,800"
-#   Then I reenter my house price with "126000"
-#   And I click next again
-#   And I see the stamp duty I will have to pay is "£3,780"
+@javascript
+Scenario: I recalculate for second home
+  Given I visit the Stamp Duty page
+  When I enter my house price with "260000"
+  And I select to calculate for a second home
+  And I click next
+  And I see the stamp duty I will have to pay is "£7,800"
+  Then I reenter my house price with "126000"
+  And I click next again
+  And I see the stamp duty I will have to pay is "£3,780"

--- a/features/step_definitions/stamp_duty.rb
+++ b/features/step_definitions/stamp_duty.rb
@@ -59,7 +59,7 @@ Given(/^I am a first time buyer$/) do
 end
 
 Given(/^I am a next home buyer$/) do
-  @stamp_duty.select('buying my next home', from: @buyer_type)
+  @stamp_duty.select('buying my first or my next home', from: @buyer_type)
 end
 
 Given("I am an additional or buy-to-let property buyer") do

--- a/jenkins/test
+++ b/jenkins/test
@@ -34,7 +34,7 @@ function info {
 
 run npm install --quiet
 run bundle install
-run bundle update brakeman --quiet
+# run bundle update brakeman --quiet
 run bundle exec bowndler update --allow-root
 run bundle exec rspec -f progress
 run bundle exec cucumber -f progress

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 3
-    MINOR = 13
+    MINOR = 14
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')

--- a/spec/controllers/land_transaction_taxes_controller_spec.rb
+++ b/spec/controllers/land_transaction_taxes_controller_spec.rb
@@ -10,13 +10,8 @@ module MortgageCalculator
           [
             {
               start: 0,
-              end: 180_000,
-              rate: 0
-            },
-            {
-              start: 180_000.01,
               end: 250_000,
-              rate: 3.5
+              rate: 0
             },
             {
               start: 250_000.01,
@@ -37,6 +32,41 @@ module MortgageCalculator
               start: 1_500_000.01,
               end: nil,
               rate: 12
+            }
+          ]
+        )
+
+        expect(controller.higher_rates).to eq(
+          [
+            {
+              start: 0,
+              end: 180_000,
+              rate: 3
+            },
+            {
+              start: 180_000.01,
+              end: 250_000,
+              rate: 6.5
+            },
+            {
+              start: 250_000.01,
+              end: 400_000,
+              rate: 8
+            },
+            {
+              start: 400_000.01,
+              end: 750_000,
+              rate: 10.5
+            },
+            {
+              start: 750_000.01,
+              end: 1_500_000,
+              rate: 13
+            },
+            {
+              start: 1_500_000.01,
+              end: nil,
+              rate: 15
             }
           ]
         )

--- a/spec/helpers/land_and_buildings_transaction_taxes_helper_spec.rb
+++ b/spec/helpers/land_and_buildings_transaction_taxes_helper_spec.rb
@@ -5,7 +5,7 @@ module MortgageCalculator
     describe '#calculator_config_json' do
       it 'sets the first theshold to the correct value' do
         config = JSON.parse(calculator_config_json)
-        expect(config["standard"].first["threshold"]).to eq(145000)
+        expect(config["standard"].first["threshold"]).to eq(250000)
       end
     end
 
@@ -29,26 +29,9 @@ module MortgageCalculator
       end
     end
 
-    describe '#buyer_journey_examples' do
-      # rubocop:disable RSpec/ExampleLength
-      it 'returns array of example purchase prices with tax relief amounts' do
-        expected_result = [
-          { purchase_price: 'Up to £145,000', standard_lbtt: '£0', ftb_relief: '£0', ftb_lbtt: '£0' },
-          { purchase_price: '£155,000', standard_lbtt: '£200', ftb_relief: '£200', ftb_lbtt: '£0' },
-          { purchase_price: '£175,000', standard_lbtt: '£600', ftb_relief: '£600', ftb_lbtt: '£0' },
-          { purchase_price: '£250,000', standard_lbtt: '£2,100', ftb_relief: '£600', ftb_lbtt: '£1,500' },
-          { purchase_price: '£325,500', standard_lbtt: '£5,900', ftb_relief: '£600', ftb_lbtt: '£5,300' },
-          { purchase_price: '£750,500', standard_lbtt: '£48,410', ftb_relief: '£600', ftb_lbtt: '£47,810' }
-        ]
-
-        expect(buyer_journey_examples).to eq(expected_result)
-      end
-      # rubocop:enable RSpec/ExampleLength
-    end
-
     describe '#ftb_starting_price' do
       it 'returns the formatted price at which lbtt becomes payable for first time buyers' do
-        expect(ftb_starting_price).to eq('£175,000')
+        expect(ftb_starting_price).to eq('£250,000')
       end
     end
   end

--- a/spec/helpers/land_transaction_taxes_helper_spec.rb
+++ b/spec/helpers/land_transaction_taxes_helper_spec.rb
@@ -5,7 +5,7 @@ module MortgageCalculator
     describe '#calculator_config_json' do
       it 'sets the first theshold to the correct value' do
         config = JSON.parse(calculator_config_json)
-        expect(config["standard"].first["threshold"]).to eq(180000)
+        expect(config["standard"].first["threshold"]).to eq(250000)
       end
     end
 

--- a/spec/models/land_and_buildings_transaction_tax_spec.rb
+++ b/spec/models/land_and_buildings_transaction_tax_spec.rb
@@ -165,25 +165,25 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is first time buy' do
         let(:buyer_type) { 'isFTB' }
 
-        its(:tax_due) { is_expected.to eql(200) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.11) }
-        its(:total_due) { is_expected.to eq(185_200) }
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eq(185_000) }
       end
 
       context 'and is next home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(800) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.43) }
-        its(:total_due) { is_expected.to eql(185_800) }
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eql(185_000) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(8200) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.43) }
-        its(:total_due) { is_expected.to eq(193_200) }
+        its(:tax_due) { is_expected.to eq(7_400) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(4) }
+        its(:total_due) { is_expected.to eq(192_400) }
       end
     end
 
@@ -193,25 +193,25 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is first time buy' do
         let(:buyer_type) { 'isFTB' }
 
-        its(:tax_due) { is_expected.to eql(2750) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.00) }
-        its(:total_due) { is_expected.to eql(277_750) }
+        its(:tax_due) { is_expected.to eql(1250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.454545454545455) }
+        its(:total_due) { is_expected.to eql(276250) }
       end
 
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(3350) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.22) }
-        its(:total_due) { is_expected.to eql(278_350) }
+        its(:tax_due) { is_expected.to eql(1250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.454545454545455) }
+        its(:total_due) { is_expected.to eql(276250) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(14_350) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(5.22) }
-        its(:total_due) { is_expected.to eq(289_350) }
+        its(:tax_due) { is_expected.to eq(12250) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.454545454545455) }
+        its(:total_due) { is_expected.to eq(287250) }
       end
     end
 
@@ -221,25 +221,25 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is first time buy' do
         let(:buyer_type) { 'isFTB' }
 
-        its(:tax_due) { is_expected.to eql(4000) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.33) }
-        its(:total_due) { is_expected.to eql(304_000) }
+        its(:tax_due) { is_expected.to eql(2500) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.833333333333333) }
+        its(:total_due) { is_expected.to eql(302500) }
       end
 
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(4600) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.53) }
-        its(:total_due) { is_expected.to eql(304_600) }
+        its(:tax_due) { is_expected.to eql(2500) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.833333333333333) }
+        its(:total_due) { is_expected.to eql(302500) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(16_600) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(5.53) }
-        its(:total_due) { is_expected.to eq(316_600) }
+        its(:tax_due) { is_expected.to eq(14_500) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.833333333333333) }
+        its(:total_due) { is_expected.to eq(314_500) }
       end
     end
 
@@ -249,25 +249,25 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is first time buy' do
         let(:buyer_type) { 'isFTB' }
 
-        its(:tax_due) { is_expected.to eql(21750) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.44) }
-        its(:total_due) { is_expected.to eql(511_750) }
+        its(:tax_due) { is_expected.to eql(20250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.13265306122449) }
+        its(:total_due) { is_expected.to eql(510250) }
       end
 
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(22_350) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.56) }
-        its(:total_due) { is_expected.to eql(512_350) }
+        its(:tax_due) { is_expected.to eql(20250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.13265306122449) }
+        its(:total_due) { is_expected.to eql(510250) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(41_950) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(8.56) }
-        its(:total_due) { is_expected.to eq(531_950) }
+        its(:tax_due) { is_expected.to eq(39_850) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(8.13265306122449) }
+        its(:total_due) { is_expected.to eq(529_850) }
       end
     end
 
@@ -277,25 +277,25 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is first time buy' do
         let(:buyer_type) { 'isFTB' }
 
-        its(:tax_due) { is_expected.to eql(23750) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.66) }
-        its(:total_due) { is_expected.to eql(533_750) }
+        its(:tax_due) { is_expected.to eql(22250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.362745098039216) }
+        its(:total_due) { is_expected.to eql(532250) }
       end
 
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(24_350) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.77) }
-        its(:total_due) { is_expected.to eql(534_350) }
+        its(:tax_due) { is_expected.to eql(22250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(4.362745098039216) }
+        its(:total_due) { is_expected.to eql(532250) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(44_750) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(8.77) }
-        its(:total_due) { is_expected.to eq(554_750) }
+        its(:tax_due) { is_expected.to eq(42650) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(8.362745098039216) }
+        its(:total_due) { is_expected.to eq(552650) }
       end
     end
 
@@ -305,25 +305,25 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is first time buy' do
         let(:buyer_type) { 'isFTB' }
 
-        its(:tax_due) { is_expected.to eql(70250) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(7.49) }
-        its(:total_due) { is_expected.to eql(1_007_750) }
+        its(:tax_due) { is_expected.to eql(68750) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(7.333333333333333) }
+        its(:total_due) { is_expected.to eql(1006250) }
       end
 
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(70_850) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(7.56) }
-        its(:total_due) { is_expected.to eql(1_008_350) }
+        its(:tax_due) { is_expected.to eql(68750) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(7.333333333333333) }
+        its(:total_due) { is_expected.to eql(1006250) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(108_350) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(11.56) }
-        its(:total_due) { is_expected.to eq(1_045_850) }
+        its(:tax_due) { is_expected.to eq(106_250) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(11.333333333333333) }
+        its(:total_due) { is_expected.to eq(1_043_750) }
       end
     end
 
@@ -333,25 +333,25 @@ describe MortgageCalculator::LandAndBuildingsTransactionTax do
       context 'and is first time buy' do
         let(:buyer_type) { 'isFTB' }
 
-        its(:tax_due) { is_expected.to eql(209_750) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(9.99) }
-        its(:total_due) { is_expected.to eql(2_309_750) }
+        its(:tax_due) { is_expected.to eql(208250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(9.916666666666667) }
+        its(:total_due) { is_expected.to eql(2308250) }
       end
 
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(210_350) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(10.01) }
-        its(:total_due) { is_expected.to eql(2_310_350) }
+        its(:tax_due) { is_expected.to eql(208250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(9.916666666666667) }
+        its(:total_due) { is_expected.to eql(2308250) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(294_350) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(14.02) }
-        its(:total_due) { is_expected.to eq(2_394_350) }
+        its(:tax_due) { is_expected.to eq(292_250) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(13.916666666666667) }
+        its(:total_due) { is_expected.to eq(2_392_250) }
       end
     end
   end

--- a/spec/models/land_transaction_tax_spec.rb
+++ b/spec/models/land_transaction_tax_spec.rb
@@ -83,7 +83,7 @@ describe MortgageCalculator::LandTransactionTax do
 
         its(:tax_due) { is_expected.to be_zero }
         its(:percentage_tax) { is_expected.to be_zero }
-        its(:total_due) { is_expected.to eq(39_000) }
+        its(:total_due) { is_expected.to eq(39000) }
       end
     end
 
@@ -103,7 +103,7 @@ describe MortgageCalculator::LandTransactionTax do
 
         its(:tax_due) { is_expected.to eq(1200) }
         its(:percentage_tax) { is_expected.to eq(3) }
-        its(:total_due) { is_expected.to eq(41_200) }
+        its(:total_due) { is_expected.to eq(41200) }
       end
     end
 
@@ -123,7 +123,7 @@ describe MortgageCalculator::LandTransactionTax do
 
         its(:tax_due) { is_expected.to eq(4350) }
         its(:percentage_tax) { is_expected.to eq(3) }
-        its(:total_due) { is_expected.to eq(149_350) }
+        its(:total_due) { is_expected.to eq(149350) }
       end
     end
 
@@ -133,17 +133,17 @@ describe MortgageCalculator::LandTransactionTax do
       context 'and is next home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(175) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.09) }
-        its(:total_due) { is_expected.to eql(185_175) }
+        its(:tax_due) { is_expected.to be_zero }
+        its(:percentage_tax) { is_expected.to be_zero }
+        its(:total_due) { is_expected.to eql(185_000) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(5725) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(3.09) }
-        its(:total_due) { is_expected.to eq(190_725) }
+        its(:tax_due) { is_expected.to eql(5725) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(3.094594594594595) }
+        its(:total_due) { is_expected.to eql(190725) }
       end
     end
 
@@ -153,17 +153,17 @@ describe MortgageCalculator::LandTransactionTax do
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(3700) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.35) }
-        its(:total_due) { is_expected.to eql(278_700) }
+        its(:tax_due) { is_expected.to eql(1250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.454545454545455) }
+        its(:total_due) { is_expected.to eql(276250) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(11_950) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.35) }
-        its(:total_due) { is_expected.to eq(286_950) }
+        its(:tax_due) { is_expected.to eq(11950) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(4.345454545454545) }
+        its(:total_due) { is_expected.to eq(286950) }
       end
     end
 
@@ -173,17 +173,17 @@ describe MortgageCalculator::LandTransactionTax do
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(4950) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(1.65) }
-        its(:total_due) { is_expected.to eql(304_950) }
+        its(:tax_due) { is_expected.to eql(2500) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(0.833333333333333) }
+        its(:total_due) { is_expected.to eql(302500) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(13_950) }
+        its(:tax_due) { is_expected.to eq(13950) }
         its(:percentage_tax) { is_expected.to be_within(0.1).of(4.65) }
-        its(:total_due) { is_expected.to eq(313_950) }
+        its(:total_due) { is_expected.to eq(313950) }
       end
     end
 
@@ -193,17 +193,17 @@ describe MortgageCalculator::LandTransactionTax do
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(16_700) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(3.41) }
-        its(:total_due) { is_expected.to eql(506_700) }
+        its(:tax_due) { is_expected.to eql(14250) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(2.908163265306122) }
+        its(:total_due) { is_expected.to eql(504250) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(31_400) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(6.41) }
-        its(:total_due) { is_expected.to eq(521_400) }
+        its(:tax_due) { is_expected.to eq(31400) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(6.408163265306122) }
+        its(:total_due) { is_expected.to eq(521400) }
       end
     end
 
@@ -213,17 +213,17 @@ describe MortgageCalculator::LandTransactionTax do
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(18_200) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(3.57) }
-        its(:total_due) { is_expected.to eql(528_200) }
+        its(:tax_due) { is_expected.to eql(15750) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(3.088235294117647) }
+        its(:total_due) { is_expected.to eql(525750) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(33_500) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(6.57) }
-        its(:total_due) { is_expected.to eq(543_500) }
+        its(:tax_due) { is_expected.to eq(33500) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(6.568627450980392) }
+        its(:total_due) { is_expected.to eq(543500) }
       end
     end
 
@@ -233,17 +233,17 @@ describe MortgageCalculator::LandTransactionTax do
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(54_950) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(5.86) }
-        its(:total_due) { is_expected.to eql(992_450) }
+        its(:tax_due) { is_expected.to eql(52500) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(5.6) }
+        its(:total_due) { is_expected.to eql(990000) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(83_075) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(8.86) }
-        its(:total_due) { is_expected.to eq(1_020_575) }
+        its(:tax_due) { is_expected.to eq(83075) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(8.861333333333333) }
+        its(:total_due) { is_expected.to eq(1020575) }
       end
     end
 
@@ -253,17 +253,17 @@ describe MortgageCalculator::LandTransactionTax do
       context 'and is not a second home' do
         let(:buyer_type) { 'isNextHome' }
 
-        its(:tax_due) { is_expected.to eql(183_200) }
-        its(:percentage_tax) { is_expected.to be_within(0.1).of(8.72) }
-        its(:total_due) { is_expected.to eql(2_283_200) }
+        its(:tax_due) { is_expected.to eql(180750) }
+        its(:percentage_tax) { is_expected.to be_within(0.1).of(8.607142857142857) }
+        its(:total_due) { is_expected.to eql(2280750) }
       end
 
       context 'and is a second home' do
         let(:buyer_type) { 'isSecondHome' }
 
-        its(:tax_due) { is_expected.to eq(246_200) }
-        its(:percentage_tax) { is_expected.to be_within(0.01).of(11.72) }
-        its(:total_due) { is_expected.to eq(2_346_200) }
+        its(:tax_due) { is_expected.to eq(246200) }
+        its(:percentage_tax) { is_expected.to be_within(0.01).of(11.723809523809524) }
+        its(:total_due) { is_expected.to eq(2346200) }
       end
     end
   end


### PR DESCRIPTION
[TP11744](https://maps.tpondemand.com/entity/11744-update-stamp-duty-calculator-and-put)

The work contained in this PR restores everything that was removed or added to its original state as part of the work to take down the existing three Stamp Duty Calculator tools and then makes the appropriate updates for them to be put back live. 

The work is in a few parts: 
- Restore the three calculators to their original state 
- Make content and text changes to the England/NI Calculator
- Make content and text changes to the Scotland Calculator
- Make content and text changes to the Wales Calculator
- Make updates to the calculations for the Scotland Calculator
- Make updates to the calculations for the Wales Calculator
- Add a new table for the calculations for the Wales Calculator

The commits roughly reflect these stages so it is probably best to review it on the basis of individual commits. 