### PR TITLE
11778 lbtt update table

### DIFF
--- a/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
+++ b/app/assets/stylesheets/mortgage_calculator/components/_mortgagecalc.scss
@@ -186,6 +186,10 @@
   }
 }
 
+.mortgagecalc__table__common-row {
+  vertical-align: middle; 
+}
+
 .mortgagecalc__table__lbtt-price {
   width: 34%;
 

--- a/app/views/mortgage_calculator/property_tax_calculator/_bands_table.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/_bands_table.html.erb
@@ -13,11 +13,19 @@
     </tr>
   </thead>
   <tbody>
-    <% rates.each do |rate| %>
+    <% rates.each_with_index do |rate, index| %>
       <tr>
         <td class="mortgagecalc__table__price"><%= band(rate[:start], rate[:end]) %></td>
         <td class="mortgagecalc__table__rate"><%= rate[:rate] %>%</td>
-        <td class="mortgagecalc__table__extra"><%= second_home_rate(rate[:rate]) %>%</td>
+        <% if i18n_locale_namespace == 'land_and_buildings_transaction_tax' %>
+          <% if index == 0 %>
+            <td class="mortgagecalc__table__extra mortgagecalc__table__common-row" rowspan="<%= rates.length %>">
+              <%= I18n.t("#{i18n_locale_namespace}.table.extra_rate", rate: second_home_rate(rate[:rate])) %>
+            </td>
+          <% end %>
+        <% else %>
+          <td class="mortgagecalc__table__extra"><%= second_home_rate(rate[:rate]) %>%</td>
+        <% end %>
       </tr>
      <% end %>
   </tbody>

--- a/config/locales/land_and_buildings_transaction_tax.cy.yml
+++ b/config/locales/land_and_buildings_transaction_tax.cy.yml
@@ -31,7 +31,7 @@ cy:
     how_calculated_ftb_5: "Er enghraifft:"
     how_calculated: "Mae Treth Trafodiad Tir ac Adeiladau (LBTT) yn dreth a gymhwysir i drafodion tir ac adeiladau preswyl ac amhreswyl (gan gynnwys prydlesi masnachol). Mae'r dreth yn daladwy ar wahanol gyfraddau ar bob cyfran o'r pris prynu o fewn bandiau treth penodedig. Dim ond i'r rhan o bris yr eiddo sy'n dod o fewn y band hwnnw y mae'r gyfradd ganrannol ar gyfer pob band yn cael ei chymhwyso. Er enghraifft, ni fyddai rhywun sy'n prynu eiddo am £ 280,000 yn talu unrhyw LBTT ar werth yr eiddo hyd at £250,000 ac yna 5% o'r gwerth rhwng £ 250,000 a £280,000. Yn yr achos hwn, cyfanswm y LBTT a dalwyd fyddai £1,500."
     how_calculated_additional: "Efallai y bydd yn rhaid i unrhyw un sy'n prynu eiddo preswyl ychwanegol yn yr Alban (fel ail gartref neu eiddo prynu-i-osod) dalu Atodiad Annedd Ychwanegol (ADS) os yw'r pris prynu yn £ 40,000 neu fwy. Yn yr enghraifft uchod, pe bai'r eiddo'n ail gartref, cyfanswm y LBTT a dalwyd fyddai £1,500 PLWS ADS o £11,200 (4% o £280,000), felly cyfanswm o £12,700. Nodir y cyfraddau a'r bandiau ar gyfer LBTT isod:"
-    how_calculated_extra: "* Nid yw eiddo dan %{amount} yn destun yr Atodiad Annedd Atodol ar gyfer ail gartref"
+    how_calculated_extra: Nid yw eiddo o dan %{amount} yn destun i Atodiad Annedd Ychwanegol (ADS) ond os yw ADS yn ddyledus mae'n daladwy ar gyfanswm y pris prynu.
     describe_price_field: "Gwnewch yn siŵr eich bod yn clirio'r rhif presennol cyn rhoi un newydd i mewn."
     activemodel:
       attributes:
@@ -46,16 +46,17 @@ cy:
       click_to_expand: Cliciwch i ehangu
       FTB_conditional: "You are not eligible for relief on Land and Buildings Transaction Tax because the property value is greater than %{amount}."
     table:
-      property_price_header: "Pris prynu"
+      property_price_header: Pris prynu’r eiddo
       rate_header: "Cyfradd LBTT safonol"
       standard_bill_header: "Bil LBTT safonol"
-      verbose_rate_header: "Cyfradd Treth Trafodiadau Tir ac Adeiladau (LBTT)"
+      verbose_rate_header: Cyfradd Treth Trafodiad Tir ac Adeiladau (LBTT) (eiddo preswyl sengl neu luosog)
       ftb_relief_amount_header: "Swm o Ostyngiad Prynwr tro Cyntaf"
       ftb_total_amount_header: "Y cyfanswm i'w dalu fel prynwr am y tro cyntaf"
-      extra_rate_header: "Atodiad Prynu-i-osod / Annedd Atodol (ADS)*"
+      extra_rate_header: Atodiad Annedd Ychwanegol (ADS) ar ail eiddo preswyl neu eiddo preswyl ychwanegol
       standard_rates_apply: "Codir cyfraddau safonol (gweler isod)"
       min: "Hyd at %{value}"
       max: "Dros %{value}"
+      extra_rate: "%{rate}% o'r pris prynu (wedi'i dalu yn ychwanegol at unrhyw LBTT sy'n ddyledus)"
     next_steps:
       learn_more:
         title: "A wyddech chi?"

--- a/config/locales/land_and_buildings_transaction_tax.en.yml
+++ b/config/locales/land_and_buildings_transaction_tax.en.yml
@@ -31,7 +31,7 @@ en:
     how_calculated_ftb_5: "For example:"
     how_calculated: "Land and Buildings Transaction Tax (LBTT) is a tax applied to residential and non-residential land and buildings transactions (including commercial leases). The tax is payable at different rates on each portion of the purchase price within specified tax bands. The percentage rate for each band is applied only to the part of the property price that falls within that band. For example, someone buying a property for £280,000 would pay no LBTT on the value of the property up to £250,000 and then 5% of the value between £250,000 and £280,000. In this case the total LBTT paid would be £1,500."
     how_calculated_additional: "Anyone buying an additional residential property in Scotland (such as a second home or a buy-to-let property) may also have to pay an Additional Dwelling Supplement (ADS) if the purchase price is £40,000 or more. In the example above, if the property was a second home the total amount of LBTT paid would be £1,500 PLUS ADS of £11,200 (4% of £280,000), so £12,700 in total. The rates and bands for LBTT are set out below:"
-    how_calculated_extra: "* Properties under %{amount} are not subject to second home Additional Dwelling Supplement"
+    how_calculated_extra: Properties under %{amount} are not subject to Additional Dwelling Supplement (ADS) but if ADS is due it is payable on the total purchase price. 
     describe_price_field: Make sure to clear the existing number before entering the new number.
     activemodel:
       attributes:
@@ -46,16 +46,17 @@ en:
       click_to_expand: Click to expand.
       FTB_conditional: "You are not eligible for relief on Land and Buildings Transaction Tax because the property value is greater than %{amount}."
     table:
-      property_price_header: "Purchase price"
+      property_price_header: Purchase price of property
       rate_header: "Standard LBTT rate"
       standard_bill_header: "Standard LBTT bill"
-      verbose_rate_header: "Rate of Land and Buildings Transaction Tax (LBTT)"
+      verbose_rate_header: Rate of Land and Buildings Transaction Tax (LBTT) (single or multiple residential properties)
       ftb_relief_amount_header: "Amount of First-time Buyer Relief"
       ftb_total_amount_header: "Total to pay for a first-time buyer"
-      extra_rate_header: "Buy to Let/ Additional Dwelling Supplement (ADS)*"
+      extra_rate_header: Additional Dwelling Supplement (ADS) on second or additional residential property
       standard_rates_apply: "Standard rates apply (see below)"
       min: "Up to %{value}"
       max: "Over %{value}"
+      extra_rate: "%{rate}% of purchase price (paid in addition to any LBTT due)"
     next_steps:
       learn_more:
         title: "Did you know?"

--- a/features/lbtt_how_calculated_panel.feature
+++ b/features/lbtt_how_calculated_panel.feature
@@ -24,11 +24,11 @@ Scenario: LBTT How is this calculated panel - Next home buyer journey
   When I progress to the results page
   And I click on the How is this Calculated information icon
   Then I should see the values on the information panel as:
-  | Purchase price      | Rate of Land and Buildings Transaction Tax (LBTT) | Buy to Let/ Additional Dwelling Supplement (ADS)* |
-  | Up to £250,000      | 0%                 | 4%                           |
-  | £250,001 - £325,000 | 5%                 | 4%                           |
-  | £325,001 - £750,000 | 10%                | 4%                           |
-  | Over £750,000       | 12%                | 4%                           |
+  | Purchase price of property | Rate of Land and Buildings Transaction Tax (LBTT) (single or multiple residential properties) | Additional Dwelling Supplement (ADS) on second or additional residential property |
+  | Up to £250,000             | 0%                                                                                            | 4% of purchase price (paid in addition to any LBTT due)                           |
+  | £250,001 - £325,000        | 5%                                                                                            |                                                                                   |
+  | £325,001 - £750,000        | 10%                                                                                           |                                                                                   |
+  | Over £750,000              | 12%                                                                                           |                                                                                   |
 
 Scenario: LBTT How is this calculated panel - Additional home buyer journey
   Given I visit the land and buildings transaction tax page
@@ -36,8 +36,8 @@ Scenario: LBTT How is this calculated panel - Additional home buyer journey
   When I progress to the results page
   And I click on the How is this Calculated information icon
   Then I should see the values on the information panel as:
-  | Purchase price      | Rate of Land and Buildings Transaction Tax (LBTT) | Buy to Let/ Additional Dwelling Supplement (ADS)* |
-  | Up to £250,000      | 0%                 | 4%                           |
-  | £250,001 - £325,000 | 5%                 | 4%                           |
-  | £325,001 - £750,000 | 10%                | 4%                           |
-  | Over £750,000       | 12%                | 4%                           |
+  | Purchase price of property | Rate of Land and Buildings Transaction Tax (LBTT) (single or multiple residential properties) | Additional Dwelling Supplement (ADS) on second or additional residential property |
+  | Up to £250,000             | 0%                                                                                            | 4% of purchase price (paid in addition to any LBTT due)                           |
+  | £250,001 - £325,000        | 5%                                                                                            |                                                                                   |
+  | £325,001 - £750,000        | 10%                                                                                           |                                                                                   |
+  | Over £750,000              | 12%                                                                                           |                                                                                   |

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 3
-    MINOR = 14
+    MINOR = 15
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
[TP11778](https://maps.tpondemand.com/entity/11778-update-to-stamp-duty-calculator-for)

This work updates the display of the table that explains how bands are calculated on the LBTT tool. This is required to add clarity to the user, particularly with regards to the higher rate of tax. 

The changes consist of 
- Updating the wording of table headings
- Updating the wording of the Additional Dwelling Supplement column
- Updating the wording of the table footer 

**Current table**

![image](https://user-images.githubusercontent.com/6080548/94586941-cab3a000-0279-11eb-935d-2892f116c12e.png)

**Updated table**

![image](https://user-images.githubusercontent.com/6080548/94586821-9d66f200-0279-11eb-84d9-528f12ccfc9d.png)
