### PR TITLE
Adds holding message to tool

### DIFF
--- a/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
@@ -13,9 +13,11 @@
       <div class="stamp-duty__container">
         <h1 class="stamp-duty__heading"><%= I18n.t("#{i18n_locale_namespace}.heading") %></h1>
         <h2 class="intro stamp-duty__subheading"><%= I18n.t("#{i18n_locale_namespace}.title") %></h2>
-        <p>
-          <%= I18n.t("#{i18n_locale_namespace}.subtitle").html_safe %>
-        </p>
+
+        <% I18n.t("#{i18n_locale_namespace}.subtitle_paras").each do |para| %>
+          <p><%= para.html_safe %></p>
+        <% end %>
+
         <%= render 'form_step1' %>
 
         <hr />

--- a/config/locales/land_and_buildings_transaction_tax.cy.yml
+++ b/config/locales/land_and_buildings_transaction_tax.cy.yml
@@ -8,7 +8,8 @@ cy:
     tooltip_hide: cuddio cymorth
     tool_name: "cyfrifiannell-treth-trafodion-tir-ac-adeiladau"
     heading: "Cyfrifiannell Treth Trafodion Tir ac Adeiladau"
-    subtitle: Mae Treth Trafodiadau Tir ac Adeiladau (LBTT) yn dâl ar drafodiadau tir yn yr Alban. Mae’n rhaid i drafodiadau tir gael eu hysbysu i Refeniw’r Alban oni bai bod yr ystyriaeth daladwy yn llai na £40,000 neu fod y trafodiad wedi'i eithrio fel arall. Er enghraifft, trafodion mewn cysylltiad â gorchymyn llys sy'n ymwneud ag ysgariad neu ddiddymiad partneriaeth sifil. Efallai y bydd Atodiad Annedd Atodol (ADS) yn ddyledus wrth brynu eiddo ychwanegol. Cyfrifoldeb y trethdalwr yw cwblhau a chyflwyno ffurflen LBTT gywir, lle bo angen, a thalu unrhyw dreth sy'n ddyledus.
+    subtitle_paras: 
+      - Mae Treth Trafodiadau Tir ac Adeiladau (LBTT) yn dâl ar drafodiadau tir yn yr Alban. Mae’n rhaid i drafodiadau tir gael eu hysbysu i Refeniw’r Alban oni bai bod yr ystyriaeth daladwy yn llai na £40,000 neu fod y trafodiad wedi'i eithrio fel arall. Er enghraifft, trafodion mewn cysylltiad â gorchymyn llys sy'n ymwneud ag ysgariad neu ddiddymiad partneriaeth sifil. Efallai y bydd Atodiad Annedd Atodol (ADS) yn ddyledus wrth brynu eiddo ychwanegol. Cyfrifoldeb y trethdalwr yw cwblhau a chyflwyno ffurflen LBTT gywir, lle bo angen, a thalu unrhyw dreth sy'n ddyledus.
     heading_results: "Cyfrifiannell Treth Trafodion Tir ac Adeiladau - Eich canlyniadau"
     title: "Cyfrifwch y Dreth Trafodion Tir ac Adeiladau ar eich eiddo preswyl yn yr Alban"
     next: "Nesaf"

--- a/config/locales/land_and_buildings_transaction_tax.en.yml
+++ b/config/locales/land_and_buildings_transaction_tax.en.yml
@@ -8,7 +8,8 @@ en:
     tooltip_hide: hide help
     tool_name: "land-and-buildings-transaction-tax-calculator"
     heading: "Land and Buildings Transaction Tax (LBTT) calculator"
-    subtitle: Land and Buildings Transaction Tax (LBTT) is a charge on land transactions in Scotland. Land transactions must be notified to Revenue Scotland unless the chargeable consideration is less than £40,000 or the transaction is otherwise exempt. For example, transactions in connection with a court order relating to divorce or dissolution of civil partnership. An Additional Dwelling Supplement (ADS), may be due on the purchase of an additional property. It is the responsibility of the taxpayer to complete and submit an accurate LBTT return, where required, and pay any tax due.
+    subtitle_paras: 
+      - Land and Buildings Transaction Tax (LBTT) is a charge on land transactions in Scotland. Land transactions must be notified to Revenue Scotland unless the chargeable consideration is less than £40,000 or the transaction is otherwise exempt. For example, transactions in connection with a court order relating to divorce or dissolution of civil partnership. An Additional Dwelling Supplement (ADS), may be due on the purchase of an additional property. It is the responsibility of the taxpayer to complete and submit an accurate LBTT return, where required, and pay any tax due.
     heading_results: "Land and Buildings Transaction Tax (LBTT) calculator - Your Results"
     title: "Calculate the Land and Buildings Transaction Tax on your residential property in Scotland"
     next: Next

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -11,7 +11,9 @@ cy:
     heading: "Cyfrifiannell treth stamp"
     heading_results: "Cyfrifiannell treth stamp - Eich canlyniadau"
     title: "Cyfrifwch y dreth stamp ar eich eiddo preswyl prynu yng Lloegr neu Ogledd Iwerddon"
-    subtitle: Hyd at 31 Mawrth 2021, ni fyddwch yn talu unrhyw Dreth Tir Treth Stamp (SDLT) ar brynu'ch prif eiddo sy'n costio hyd at £500,000. Rydych yn talu treth wahanol os yw'ch eiddo neu'ch tir yn yr <a href="/cy/tools/prynu-ty/cyfrifiannell-treth-trafodion-tir-ac-adeiladau-alban" target="_blank">Alban</a> neu <a href="/cy/tools/prynu-ty/cyfrifiannell-treth-trafodiadau-tir-cymru" target="_blank">Gymru</a>. Bydd yn rhaid i unrhyw un sy'n prynu eiddo preswyl ychwanegol gwerth £40,000 neu fwy dalu cyfradd ychwanegol o dreth stamp hyd yn oed os yw'r eiddo rydych eisoes yn berchen arno dramor. Chi sy'n gyfrifol am sicrhau bod ffurflen SDLT yn cael ei hanfon at CThEM ac yn talu unrhyw dreth sy'n ddyledus cyn pen 14 diwrnod o ddyddiad y trafodiad (y dyddiad cwblhau fel arfer).
+    subtitle_paras: 
+      - Hyd at 1 Ebrill 2021, ni fyddwch yn talu unrhyw Dreth Tir Treth Stamp (SDLT) ar brynu'ch prif eiddo sy'n costio hyd at £500,000. Os yw dyddiad cwblhau eich pryniant tŷ ar neu ar ôl y dyddiad hwn, rydym yn argymell eich bod yn defnyddio'r <a href="https://www.tax.service.gov.uk/calculate-stamp-duty-land-tax/#/intro" target="_blank">gyfrifiannell</a> hon i gyfrifo unrhyw atebolrwydd i dreth stamp ar eich pryniant eiddo.
+      - Rydych yn talu treth wahanol os yw'ch eiddo neu'ch tir yn yr <a href="/cy/tools/prynu-ty/cyfrifiannell-treth-trafodion-tir-ac-adeiladau-alban" target="_blank">Alban</a> neu <a href="/cy/tools/prynu-ty/cyfrifiannell-treth-trafodiadau-tir-cymru" target="_blank">Gymru</a>. Bydd yn rhaid i unrhyw un sy'n prynu eiddo preswyl ychwanegol gwerth £40,000 neu fwy dalu cyfradd ychwanegol o dreth stamp hyd yn oed os yw'r eiddo rydych eisoes yn berchen arno dramor. Chi sy'n gyfrifol am sicrhau bod ffurflen SDLT yn cael ei hanfon at CThEM ac yn talu unrhyw dreth sy'n ddyledus cyn pen 14 diwrnod o ddyddiad y trafodiad (y dyddiad cwblhau fel arfer).
     next: "Nesaf"
     select:
       label: Rwy'n

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -11,7 +11,9 @@ en:
     heading: "Stamp Duty calculator"
     heading_results: "Stamp Duty Calculator - Your Results"
     title: Calculate the Stamp Duty on your residential property purchase in England or Northern Ireland
-    subtitle: Until 31 March 2021, you will pay no Stamp Duty Land Tax (SDLT) on the purchase of your main property costing up to £500,000. You pay a different tax if your property or land is in <a href="/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland" target="_blank">Scotland</a> or <a href="/en/tools/house-buying/land-transaction-tax-calculator-wales" target="_blank">Wales</a>.  Anyone buying an additional residential property worth £40,000 or more will still have to pay an additional rate of stamp duty even if the property you already own is abroad. You are responsible for ensuring an SDLT return is sent to HMRC and pay any tax due within 14 days of the transaction date (usually the date of completion)..
+    subtitle_paras: 
+      - Until 1 April 2021, you will pay no Stamp Duty Land Tax (SDLT) on the purchase of your main property costing up to £500,000. If the completion date of your house purchase is on or after this date we recommend you use this <a href="https://www.tax.service.gov.uk/calculate-stamp-duty-land-tax/#/intro" target="_blank">calculator</a> to calculate any liability to stamp duty on your property purchase.
+      - You pay a different tax if your property or land is in <a href="/en/tools/house-buying/land-and-buildings-transaction-tax-calculator-scotland" target="_blank">Scotland</a> or <a href="/en/tools/house-buying/land-transaction-tax-calculator-wales" target="_blank">Wales</a>.  Anyone buying an additional residential property worth £40,000 or more will still have to pay an additional rate of stamp duty even if the property you already own is abroad. You are responsible for ensuring an SDLT return is sent to HMRC and pay any tax due within 14 days of the transaction date (usually the date of completion).
     next: Next
     select:
       label: I am

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -1,7 +1,7 @@
 module MortgageCalculator
   module Version
     MAJOR = 3
-    MINOR = 16
+    MINOR = 17
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
[TP11945](https://maps.tpondemand.com/entity/11945-urgent-holding-statement-on-stamp-duty)

This work adds a holding message to the introductory text on the calculator to signal that there will be a change in Stamp Duty rates on 1 April and to provide an alternate link. 

There is a code change in the translation files for the Scotland (LBTT) version of the tool to accommodate the change made in the view, which is shared between the two calculators. This should not effect the content of the LBTT Calculator. 

**Current copy**

![image](https://user-images.githubusercontent.com/6080548/104211842-7ac5a700-542c-11eb-8407-b57436d90cb1.png)

**Updated copy**

![image](https://user-images.githubusercontent.com/6080548/104211881-84e7a580-542c-11eb-8aae-0deeb745a2c9.png)

