### PR TITLE
12066 - Results Page Links

### DIFF
--- a/config/locales/mortgage_calculator.cy.yml
+++ b/config/locales/mortgage_calculator.cy.yml
@@ -47,7 +47,7 @@ cy:
           title: Llog yn unig
           tip_1: Golyga’r rheoliadau diweddaraf y bydd angen i chi a’ch darparwr benthyciadau gytuno ar gynllun ad-dalu ar gyfer eich morgais.
           tip_1_linktext: Darllenwch fwy
-          tip_1_url: /cy/homes/buying-a-home/help-with-mortgages/ways-of-repaying-an-interest-only-mortgage
+          tip_1_url: "https://www.moneyhelper.org.uk/cy/homes/buying-a-home/help-with-mortgages/ways-of-repaying-an-interest-only-mortgage"
           hidden_title: Eich diddordeb yn unig ad-daliadau
       tips:
         hidden_costs: Cofiwch gynllunio ar gyfer costau eraill fel ffioedd morgais, ffioedd cyfreithiol a threth stamp.
@@ -88,7 +88,7 @@ cy:
             - copy_html: "Ystyriwch gostau erail <span class='visually-hidden'>(agorir mewn ffenestr newydd)</span>"
               url: "https://www.moneyhelper.org.uk/cy/articles/amcangyfrifwch-eich-costau-prynu-a-symud-cyffredinol"
         have_you_tried:
-          title: 'Rhowch gynnig ar?'
+          title: "Rhowch gynnig ar?"
           stamp_duty: "cyfrifiannell Treth Stamp"
           affordability_calculator: "Cyfrifiannell fforddiadwyedd"
       caveat:

--- a/config/locales/mortgage_calculator.en.yml
+++ b/config/locales/mortgage_calculator.en.yml
@@ -47,7 +47,7 @@ en:
           title: Interest Only
           tip_1: The latest regulations mean you and your lender will need to agree a repayment plan for your mortgage.
           tip_1_linktext: Read more
-          tip_1_url: /en/homes/buying-a-home/help-with-mortgages/ways-of-repaying-an-interest-only-mortgage
+          tip_1_url: "https://www.moneyhelper.org.uk/en/homes/buying-a-home/help-with-mortgages/ways-of-repaying-an-interest-only-mortgage"
           hidden_title: Your interest only repayments will be
       tips:
         hidden_costs: Remember to plan for other costs like mortgage fees, legal fees and Stamp Duty tax.
@@ -88,7 +88,7 @@ en:
             - copy_html: "Think about other costs <span class='visually-hidden'>(opens in a new window)</span>"
               url: "https://www.moneyhelper.org.uk/en/articles/estimate-your-overall-buying-and-moving-costs"
         have_you_tried:
-          title: 'Have you tried?'
+          title: "Have you tried?"
           stamp_duty: "Stamp Duty calculator"
           affordability_calculator: "Affordability calculator"
       caveat:


### PR DESCRIPTION
[TP12066](https://maps.tpondemand.com/entity/12066-update-links-on-results-page-mortgage)

This PR updates the link found in the Interest Only tab on the results page.