### PR TITLE
TP-12600 TP-12656 Fix time-sensitive features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :test do
   gem 'capybara', '2.18.0'
   gem 'coffee-rails'
   gem 'cucumber', '~> 3.0.1'
-  gem 'cucumber-rails', '1.6.0'
+  gem 'cucumber-rails', '1.6.0', require: false
   gem 'launchy'
   gem 'mas-templating'
   gem 'rspec-its'

--- a/features/land_transaction_tax_calculator.feature
+++ b/features/land_transaction_tax_calculator.feature
@@ -39,6 +39,7 @@ Feature: Land Transaction Tax Calculator
 
   @javascript
   Scenario Outline: tax for next home
+    Given the date is "2021-04-01"
     When I enter a house price of <price>
     And I enter a completion date of <completion date>
     And I am a next home buyer

--- a/features/stamp_duty_buying_next_home.feature
+++ b/features/stamp_duty_buying_next_home.feature
@@ -7,6 +7,7 @@ Background:
   Given I visit the Stamp Duty page
 
 Scenario Outline: stamp duty for next home
+  Given the date is "2021-04-01"
   When I enter a house price of <price>
   And I enter a completion date of <completion date>
   And I am a next home buyer
@@ -58,6 +59,7 @@ Examples:
 
 @javascript
 Scenario Outline: stamp duty for next home
+  Given the date is "2021-04-01"
   When I enter a house price of <price>
   And I enter a completion date of <completion date>
   And I am a next home buyer

--- a/features/stamp_duty_buying_second_home.feature
+++ b/features/stamp_duty_buying_second_home.feature
@@ -6,6 +6,7 @@ I want to enter my house price
 @javascript
 Scenario Outline: stamp duty for second home
   Given I visit the Stamp Duty page
+  And the date is "2021-04-01"
   When I enter a house price of <price>
   And I enter a completion date of <completion date>
   And I select to calculate for a second home
@@ -57,6 +58,7 @@ Examples:
 
 Scenario Outline: stamp duty for second home
   Given I visit the Stamp Duty page
+  And the date is "2021-04-01"
   When I enter a house price of <price>
   And I enter a completion date of <completion date>
   And I select to calculate for a second home

--- a/features/stamp_duty_first_time_buyer.feature
+++ b/features/stamp_duty_first_time_buyer.feature
@@ -5,6 +5,7 @@ I want to enter my house price
 
 Scenario Outline: stamp duty for first home
   Given I visit the Stamp Duty page
+  And the date is "2021-04-01"
   When I enter a house price of <price>
   And I enter a completion date of <completion date>
   And I am a first time buyer
@@ -57,6 +58,7 @@ Examples:
 @javascript
 Scenario Outline: stamp duty for first home
   Given I visit the Stamp Duty page
+  And the date is "2021-04-01"
   When I enter a house price of <price>
   And I enter a completion date of <completion date>
   And I am a first time buyer

--- a/features/step_definitions/stamp_duty.rb
+++ b/features/step_definitions/stamp_duty.rb
@@ -1,5 +1,9 @@
 # encoding: UTF-8
 
+Given("the date is {string}") do |date|
+  travel_to date.to_date
+end
+
 Given /^I visit the( Welsh)? Stamp Duty (?:page|calculator)$/i do |welsh|
   welsh = (welsh =~ /welsh/i)
 

--- a/features/support/time_travel.rb
+++ b/features/support/time_travel.rb
@@ -1,0 +1,3 @@
+After do
+  travel_back
+end


### PR DESCRIPTION
The current date has to be prior to the completion date so these
features were flakey unless you explicitly time-travelled to a date you
knew was prior. This change ensures this happens only where it needs to
and will automatically travel back during the teardown phase of the
feature.

These issues were realised during the development of both #381 and #382:

https://maps.tpondemand.com/entity/12600-stamp-duty-tools-sd-lbtt-and
https://maps.tpondemand.com/entity/12656-stamp-duty-tools-scotland-tool-link
