### PR TITLE
Stamp Duty bottom link update

### DIFF
--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -36,7 +36,7 @@ cy:
         link: "https://www.moneyhelper.org.uk/cy/homes/buying-a-home/land-transaction-tax-calculator-wales"
       scotland:
         title: Cyfrifwch Dreth Trafodiadau Tir ac Adeiladau ar gyfer yr Alban
-        link: "https://www.moneyhelper.org.uk/cy/homes/buying-a-home/land-and-and-buildings-transaction-tax-calculator-scotland"
+        link: "https://www.moneyhelper.org.uk/cy/homes/buying-a-home/land-and-buildings-transaction-tax-calculator-scotland"
     recalculate: Ailgyfrifo
     how_calculated_toggle: "Sut y cyfrifir hyn?"
     how_calculated_ftb: "Mae prynwyr tro cyntaf yn gymwys i gael gostyngiad Treth Stamp ar y £300,000 cyntaf ar eiddo sy'n werth hyd at %{amount}."

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -36,7 +36,7 @@ en:
         link: "https://www.moneyhelper.org.uk/en/homes/buying-a-home/land-transaction-tax-calculator-wales"
       scotland:
         title: Calculate Land and Buildings Transaction Tax for Scotland
-        link: "https://www.moneyhelper.org.uk/en/homes/buying-a-home/land-and-and-buildings-transaction-tax-calculator-scotland"
+        link: "https://www.moneyhelper.org.uk/en/homes/buying-a-home/land-and-buildings-transaction-tax-calculator-scotland"
     recalculate: Recalculate
     how_calculated_toggle: "How is this calculated?"
     how_calculated_ftb: "First-time buyers are entitled to relief for the first £300,000 of Stamp Duty on properties up to a value of %{amount}."


### PR DESCRIPTION
[TP12656 ](https://maps.tpondemand.com/restui/board.aspx#page=board/5175634625349962976&appConfig=eyJhY2lkIjoiOUM2MjFGQzAzOEIzQTVDNDU1NjRCMUIxQ0FENkZBOTYifQ==&boardPopup=userstory/12656/silent)

This PR remove the duplication of "and" in the bottom link on stamp duty calculator.