### PR TITLE
Add a banner to highlight the tool update

### DIFF
--- a/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
+++ b/app/views/mortgage_calculator/property_tax_calculator/show.html.erb
@@ -5,6 +5,12 @@
 <% end %>
 
 <div ng-controller="CalculatorCtrl" class="mortgagecalc__container stamp-duty">
+  <div class="global-alert--warning global-alert--in-page" style="margin-bottom: 1.75rem;">
+    <div class="global-alert__content-container">
+      <p class="global-alert__message"><%= t("#{i18n_locale_namespace}.update_message") %></p>
+    </div>
+  </div>
+
   <% resource.errors.full_messages.each do |m| %>
     <span style="color:red;"><%= m %></span>
   <% end %>

--- a/config/locales/stamp_duty.cy.yml
+++ b/config/locales/stamp_duty.cy.yml
@@ -1,5 +1,6 @@
 cy:
   stamp_duty:
+    update_message: "Newidiodd cyfraddau Treth Stamp yn Lloegr a Gogledd Iwerddon ar 23 Medi 2022 ac rydym wedi diweddaru’r cyfrifiannell hwn gyda’r cyfraddau newydd."
     meta:
       title: "Cyfrifiannell Treth Stamp - Cyfrifwch y cyfraddau newydd a ddiweddarwyd ar gyfer Treth Dir y Doll Stamp"
       description: "Defnyddiwch ein cyfrifiannell Treth Stamp i gael amcangyfrif o faint o Dreth Dir y Doll Stamp y bydd angen i chi ei thalu ar eich cartref newydd yn seiliedig ar y cyfraddau newydd a ddiweddarwyd"

--- a/config/locales/stamp_duty.en.yml
+++ b/config/locales/stamp_duty.en.yml
@@ -1,5 +1,6 @@
 en:
   stamp_duty:
+    update_message: "Stamp duty rates in England and Northern Ireland changed on 23 September 2022 and we’ve updated this calculator with the new rates."
     meta:
       title: "Stamp Duty Calculator - Work out the new updated Stamp Duty Land Tax rates"
       description: "Use our Stamp Duty calculator to get an estimate of how much Stamp Duty Land Tax you’ll need to pay on your new home based on the new updated rates"

--- a/lib/mortgage_calculator/version.rb
+++ b/lib/mortgage_calculator/version.rb
@@ -2,7 +2,7 @@ module MortgageCalculator
   module Version
     MAJOR = 4
     MINOR = 2
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
Some customers may assume the tool has yet to be updated in line with
the latest rule changes.